### PR TITLE
fix: harden webcrack sandbox, block path traversal, expand deob foundation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -139,3 +139,15 @@ IDA_BRIDGE_URL=http://127.0.0.1:18081
 # VITEST_MIN_WORKERS=1
 # VITEST_IDLE_RESOURCE_TARGET=0.8
 # VITEST_CPU_SAMPLE_MS=750
+
+# ── Obfuscator.io Pro API (optional, VM obfuscation) ──────────────────
+# OBFUSCATOR_IO_API_TOKEN=your-api-token-here
+# OBFUSCATOR_IO_VERSION=5.4.1  # Optional, defaults to latest
+
+# ── CLI Flags (passed at startup) ────────────────────────────────────
+# Use --pro-api-token to configure the Pro API token
+# Use --pro-api-version to specify the API version
+# Example: jshook --pro-api-token your-token-here --pro-api-version 5.4.1
+
+# Minimum token length: 10 characters
+# If token is shorter, the process will exit with an error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,34 +6,7 @@ on:
   pull_request:
     branches: [ "main", "master" ]
 
-permissions:
-  contents: read
-  actions: write
-
 jobs:
-  prune-caches:
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Prune stale caches
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh extension install actions/gh-actions-cache 2>/dev/null || true
-          # Delete all CodeQL caches — they are recreated per run and bloat storage
-          for key in $(gh cache list --limit 100 --json key --jq '.[].key' | grep '^codeql'); do
-            gh cache delete "$key" --confirm || true
-          done
-          # Keep only the latest pnpm store cache per OS
-          for key in $(gh cache list --limit 100 --json key --jq '.[].key' | grep '^Linux-pnpm-store' | sort -u); do
-            count=$(gh cache list --limit 100 --json key --jq ".[] | select(.key==\"$key\") | .key" | wc -l)
-            if [ "$count" -gt 1 ]; then
-              gh cache list --limit 100 --json id,key,createdAt --jq "
-                .[] | select(.key==\"$key\") | .id
-              " | tail -n +2 | xargs -I{} gh cache delete {} --confirm || true
-            fi
-          done
-
   build-and-test:
     runs-on: ubuntu-latest
     strategy:
@@ -48,7 +21,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           package-manager-cache: false
@@ -71,13 +44,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
 
-      - name: Install Dependencies
-        run: pnpm install --frozen-lockfile
+       - name: Install Dependencies
+         run: pnpm install --frozen-lockfile
 
-      - name: Generate registry index
-        run: node scripts/generate-domains-index.mjs
+       - name: Security Audit
+         run: |
+           pnpm audit --audit-level high
 
-      - name: Install Playwright Browsers
+       - name: Install Playwright Browsers
         run: npx playwright install --with-deps chromium
 
       - name: Run Linters & Formatters

--- a/README.md
+++ b/README.md
@@ -87,6 +87,64 @@ The built-in surface below is generated from the runtime registry and checked in
 <!-- metadata-sync:end -->
 
 > **[View the complete Tool Reference ↗](https://vmoranv.github.io/jshookmcp/reference/)**
+> **[🔧 Configuration](https://vmoranv.github.io/jshookmcp/guide/configuration.html)**
+
+## CLI Flags and Environment Variables
+
+### Pro API Configuration
+
+The jshook CLI supports the following flags for configuring the Obfuscator.io Pro API:
+
+#### CLI Flags
+
+```bash
+# With API token
+jshook --pro-api-token <your-token>
+
+# With API token and version
+jshook --pro-api-token <your-token> --pro-api-version <version>
+```
+
+**Requirements:**
+- `--pro-api-token`: Must be at least 10 characters
+- `--pro-api-version`: Optional (defaults to latest)
+
+#### Environment Variables
+
+Alternatively, configure using environment variables:
+
+```bash
+export OBFUSCATOR_IO_API_TOKEN=<your-token>
+export OBFUSCATOR_IO_VERSION=<version>  # optional
+
+jshook
+```
+
+**Available environment variables:**
+- `OBFUSCATOR_IO_API_TOKEN`: Your Obfuscator.io Pro API token (required for Pro features)
+- `OBFUSCATOR_IO_VERSION`: API version to use (optional)
+
+### Usage Examples
+
+#### Start MCP server with Pro API token
+
+```bash
+jshook --pro-api-token abcdefghij1234567890
+```
+
+#### Start with specific API version
+
+```bash
+jshook --pro-api-token abcdefghij1234567890 --pro-api-version 1.0.0
+```
+
+#### Using environment variables
+
+```bash
+export OBFUSCATOR_IO_API_TOKEN="abcdefghij1234567890"
+export OBFUSCATOR_IO_VERSION="1.0.0"
+jshook
+```
 
 ## Project Stats
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jshookmcp/jshook",
-  "version": "0.2.9",
-  "description": "MCP server with built-in tools across multiple domains for AI-assisted JavaScript analysis and security analysis — browser automation, CDP debugging, network monitoring, JS hooks, code analysis, and workflow orchestration",
+  "version": "0.2.6",
+  "description": "MCP server with 424 built-in tools across 35 domains for AI-assisted JavaScript analysis and security analysis — browser automation, CDP debugging, network monitoring, JS hooks, code analysis, and workflow orchestration",
   "keywords": [
     "ai",
     "anti-detection",
@@ -40,8 +40,8 @@
     "url": "https://github.com/vmoranv/jshookmcp.git"
   },
   "bin": {
-    "jshook": "dist/index.mjs",
-    "jshookmcp": "dist/index.mjs"
+    "jshook": "dist/src/index.js",
+    "jshookmcp": "dist/src/index.js"
   },
   "files": [
     "dist",
@@ -50,16 +50,16 @@
     "scripts/postinstall.cjs"
   ],
   "type": "module",
-  "main": "dist/index.mjs",
-  "types": "dist/index.d.mts",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
-      "types": "./dist/index.d.mts"
+      "import": "./dist/src/index.js",
+      "types": "./dist/src/index.d.ts"
     },
     "./plugin-api": {
-      "import": "./dist/server/plugin-api.mjs",
-      "types": "./dist/server/plugin-api.d.mts"
+      "import": "./dist/src/server/plugin-api.js",
+      "types": "./dist/src/server/plugin-api.d.ts"
     }
   },
   "publishConfig": {
@@ -67,14 +67,11 @@
     "registry": "https://registry.npmjs.org"
   },
   "scripts": {
-    "build": "node scripts/clean-dist.mjs && node scripts/generate-domains-index.mjs && tsdown",
-    "build:sdk": "corepack pnpm -C packages/extension-sdk build",
-    "build:all": "corepack pnpm run build && corepack pnpm run build:sdk",
-    "build:analyze": "cross-env BUNDLE_ANALYZE=1 corepack pnpm run build && echo 'Open stats.html in browser to view bundle analysis'",
-    "typecheck": "tsc --noEmit -p tsconfig.json && corepack pnpm -C packages/extension-sdk typecheck",
+    "build": "node scripts/clean-dist.mjs && tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json --resolve-full-paths && corepack pnpm -C packages/extension-sdk build && node scripts/copy-native-scripts.mjs && node scripts/generate-entry-reexport.mjs && node scripts/fix-bin-permissions.mjs",
+    "typecheck": "tsc --noEmit -p tsconfig.build.json && corepack pnpm -C packages/extension-sdk typecheck",
     "deps:update": "corepack pnpm update -r",
     "dev": "tsx --conditions=development watch src/index.ts",
-    "start": "node dist/index.mjs",
+    "start": "node dist/src/index.js",
     "doctor": "tsx src/cli/doctor.ts",
     "docs:generate": "node scripts/generate-vitepress-reference.mjs",
     "docs:dev": "vitepress dev docs --host 127.0.0.1 --port 5173",
@@ -87,9 +84,8 @@
     "format:check": "oxfmt \"src/**\" \"tests/**\" \"!tests/tmp/**\" --check --no-error-on-unmatched-pattern",
     "test": "node scripts/run-vitest-smart.mjs run",
     "test:e2e": "cross-env E2E_TARGET_URL=https://vmoranv.github.io/jshookmcp/ vitest run --config tests/e2e/vitest.e2e.config.ts",
-    "test:e2e:perf": "cross-env E2E_TARGET_URL=https://vmoranv.github.io/jshookmcp/ E2E_COLLECT_PERFORMANCE=1 vitest run --config tests/e2e/vitest.e2e.config.ts",
     "test:coverage": "node -e \"require('fs').mkdirSync('coverage/.tmp', { recursive: true })\" && cross-env ENABLE_INJECTION_TOOLS=true COVERAGE_FULL=true node scripts/run-vitest-smart.mjs run --coverage",
-    "prepack": "corepack pnpm run metadata:check && corepack pnpm run build:all",
+    "prepack": "corepack pnpm run metadata:check && corepack pnpm run build",
     "package:verify-bin": "node scripts/verify-packed-bin.mjs",
     "package:verify-install": "node scripts/verify-packed-install.mjs",
     "package:verify-release": "node scripts/verify-release-artifact.mjs",
@@ -102,22 +98,35 @@
     "install:full": "corepack pnpm install && corepack pnpm exec camoufox-js fetch",
     "metadata:sync": "node scripts/generate-metadata.mjs --write",
     "metadata:check": "node scripts/generate-metadata.mjs --check",
-    "check:docs-format": "corepack pnpm run lint:md",
-    "search:tune": "tsx scripts/search-tune/optimize.ts",
-    "search:tune:report": "tsx scripts/search-tune/report.ts"
+    "check:docs-format": "corepack pnpm run lint:md"
   },
   "dependencies": {
     "@babel/generator": "^7.29.1",
     "@babel/parser": "^7.29.2",
     "@babel/traverse": "^7.29.0",
     "@babel/types": "^7.29.0",
+    "@huggingface/transformers": "^4.0.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "@types/escodegen": "^0.0.10",
+    "ajv": "^8.18.0",
+    "ajv-formats": "^3.0.1",
+    "axios": "^1.15.0",
+    "better-sqlite3": "12.8.0",
+    "chalk": "^5.6.2",
+    "commander": "^14.0.3",
     "dotenv": "^17.4.1",
-    "jsdom": "^29.0.2",
+    "escodegen": "^2.1.0",
+    "groq-sdk": "^1.1.2",
+    "jscodeshift": "^17.3.0",
     "koffi": "^2.15.6",
-    "mockttp": "^4.3.1",
+    "limiter": "^3.0.0",
+    "openai": "^6.34.0",
+    "ora": "^9.3.0",
     "quickjs-emscripten": "^0.32.0",
     "rebrowser-puppeteer-core": "^24.8.1",
+    "recast": "^0.23.11",
+    "shift-parser": "^8.0.0",
+    "shift-refactor": "^2.0.0",
     "tinyglobby": "^0.2.16",
     "zod": "^4.3.6"
   },
@@ -125,17 +134,17 @@
     "@types/babel__generator": "^7.27.0",
     "@types/babel__traverse": "^7.28.0",
     "@types/better-sqlite3": "^7.6.13",
-    "@types/jsdom": "^28.0.1",
     "@types/node": "^25.5.2",
     "@vitest/coverage-v8": "^4.1.4",
     "cross-env": "^10.1.0",
+    "estree-walker": "^3.0.3",
     "lefthook": "^2.1.5",
     "medium-zoom": "^1.1.0",
-    "oxfmt": "^0.46.0",
+    "nodemon": "^3.1.14",
+    "oxfmt": "^0.44.0",
     "oxlint": "^1.59.0",
-    "rollup-plugin-visualizer": "^7.0.1",
-    "tsdown": "^0.21.7",
-    "tsx": "^4.21.0",
+    "tsc-alias": "^1.8.16",
+    "tsx": "^4.16.1",
     "typescript": "^6.0.2",
     "vite": "^8.0.8",
     "vitepress": "1.6.4",
@@ -144,9 +153,7 @@
   },
   "optionalDependencies": {
     "@devicefarmer/adbkit": "^3.3.8",
-    "@huggingface/transformers": "^4.0.1",
-    "better-sqlite3": "12.9.0",
-    "camoufox-js": "^0.10.2",
+    "camoufox-js": "^0.9.3",
     "playwright-core": "^1.59.1",
     "webcrack": "^2.15.1"
   },
@@ -156,29 +163,25 @@
   "packageManager": "pnpm@10.33.0",
   "pnpm": {
     "overrides": {
-      "hono": ">=4.12.14",
-      "@hono/node-server": "1.19.13",
+      "hono": "4.12.7",
+      "@hono/node-server": "1.19.11",
       "express-rate-limit": "8.3.0",
-      "basic-ftp": ">=5.3.0",
+      "basic-ftp": "5.2.1",
       "brace-expansion": "5.0.5",
       "minimatch": "10.2.4",
       "esbuild": "0.27.3",
       "isolated-vm": "6.1.2",
       "flatted": ">=3.4.2",
       "path-to-regexp": "8.4.0",
-      "protobufjs": ">=7.5.5",
       "picomatch@^2.0.0": "2.3.2",
-      "picomatch@^4.0.0": "4.0.4",
-      "vitepress>vite": "$vite"
+      "picomatch@^4.0.0": "4.0.4"
     },
     "onlyBuiltDependencies": [
       "better-sqlite3",
       "esbuild",
       "isolated-vm",
       "koffi",
-      "lefthook",
-      "onnxruntime-node",
-      "protobufjs"
+      "lefthook"
     ]
   },
   "mcpName": "io.github.vmoranv/jshookmcp"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,20 +5,18 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  hono: '>=4.12.14'
-  '@hono/node-server': 1.19.13
+  hono: 4.12.7
+  '@hono/node-server': 1.19.11
   express-rate-limit: 8.3.0
-  basic-ftp: '>=5.3.0'
+  basic-ftp: 5.2.1
   brace-expansion: 5.0.5
   minimatch: 10.2.4
   esbuild: 0.27.3
   isolated-vm: 6.1.2
   flatted: '>=3.4.2'
   path-to-regexp: 8.4.0
-  protobufjs: '>=7.5.5'
   picomatch@^2.0.0: 2.3.2
   picomatch@^4.0.0: 4.0.4
-  vitepress>vite: ^8.0.8
 
 importers:
 
@@ -36,27 +34,72 @@ importers:
       '@babel/types':
         specifier: ^7.29.0
         version: 7.29.0
+      '@huggingface/transformers':
+        specifier: ^4.0.1
+        version: 4.2.0
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.3.6)
+      '@types/escodegen':
+        specifier: ^0.0.10
+        version: 0.0.10
+      ajv:
+        specifier: ^8.18.0
+        version: 8.18.0
+      ajv-formats:
+        specifier: ^3.0.1
+        version: 3.0.1(ajv@8.18.0)
+      axios:
+        specifier: ^1.15.0
+        version: 1.15.0
+      better-sqlite3:
+        specifier: 12.8.0
+        version: 12.8.0
+      chalk:
+        specifier: ^5.6.2
+        version: 5.6.2
+      commander:
+        specifier: ^14.0.3
+        version: 14.0.3
       dotenv:
         specifier: ^17.4.1
         version: 17.4.2
-      jsdom:
-        specifier: ^29.0.2
-        version: 29.0.2
+      escodegen:
+        specifier: ^2.1.0
+        version: 2.1.0
+      groq-sdk:
+        specifier: ^1.1.2
+        version: 1.1.2
+      jscodeshift:
+        specifier: ^17.3.0
+        version: 17.3.0
       koffi:
         specifier: ^2.15.6
         version: 2.16.1
-      mockttp:
-        specifier: ^4.3.1
-        version: 4.3.1
+      limiter:
+        specifier: ^3.0.0
+        version: 3.0.0
+      openai:
+        specifier: ^6.34.0
+        version: 6.34.0(ws@8.20.0)(zod@4.3.6)
+      ora:
+        specifier: ^9.3.0
+        version: 9.4.0
       quickjs-emscripten:
         specifier: ^0.32.0
         version: 0.32.0
       rebrowser-puppeteer-core:
         specifier: ^24.8.1
         version: 24.8.1
+      recast:
+        specifier: ^0.23.11
+        version: 0.23.11
+      shift-parser:
+        specifier: ^8.0.0
+        version: 8.0.0
+      shift-refactor:
+        specifier: ^2.0.0
+        version: 2.0.0
       tinyglobby:
         specifier: ^0.2.16
         version: 0.2.16
@@ -73,9 +116,6 @@ importers:
       '@types/better-sqlite3':
         specifier: ^7.6.13
         version: 7.6.13
-      '@types/jsdom':
-        specifier: ^28.0.1
-        version: 28.0.1
       '@types/node':
         specifier: ^25.5.2
         version: 25.6.0
@@ -85,39 +125,42 @@ importers:
       cross-env:
         specifier: ^10.1.0
         version: 10.1.0
+      estree-walker:
+        specifier: ^3.0.3
+        version: 3.0.3
       lefthook:
         specifier: ^2.1.5
         version: 2.1.6
       medium-zoom:
         specifier: ^1.1.0
         version: 1.1.0
+      nodemon:
+        specifier: ^3.1.14
+        version: 3.1.14
       oxfmt:
-        specifier: ^0.46.0
-        version: 0.46.0
+        specifier: ^0.44.0
+        version: 0.44.0
       oxlint:
         specifier: ^1.59.0
         version: 1.61.0
-      rollup-plugin-visualizer:
-        specifier: ^7.0.1
-        version: 7.0.1(rolldown@1.0.0-rc.17)
-      tsdown:
-        specifier: ^0.21.7
-        version: 0.21.10(typescript@6.0.3)
+      tsc-alias:
+        specifier: ^1.8.16
+        version: 1.8.16
       tsx:
-        specifier: ^4.21.0
-        version: 4.21.0
+        specifier: ^4.16.1
+        version: 4.16.1
       typescript:
         specifier: ^6.0.2
         version: 6.0.3
       vite:
         specifier: ^8.0.8
-        version: 8.0.10(@types/node@25.6.0)(esbuild@0.27.3)(tsx@4.21.0)
+        version: 8.0.10(@types/node@25.6.0)(esbuild@0.27.3)(tsx@4.16.1)
       vitepress:
         specifier: 1.6.4
-        version: 1.6.4(@algolia/client-search@5.50.1)(@types/node@25.6.0)(esbuild@0.27.3)(postcss@8.5.10)(search-insights@2.17.3)(tsx@4.21.0)(typescript@6.0.3)
+        version: 1.6.4(@algolia/client-search@5.50.1)(@types/node@25.6.0)(axios@1.15.0)(lightningcss@1.32.0)(postcss@8.5.10)(search-insights@2.17.3)(typescript@6.0.3)
       vitest:
         specifier: ^4.1.4
-        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.3)(tsx@4.21.0))
+        version: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.3)(tsx@4.16.1))
       vue:
         specifier: ^3.5.32
         version: 3.5.33(typescript@6.0.3)
@@ -125,15 +168,9 @@ importers:
       '@devicefarmer/adbkit':
         specifier: ^3.3.8
         version: 3.3.8
-      '@huggingface/transformers':
-        specifier: ^4.0.1
-        version: 4.2.0
-      better-sqlite3:
-        specifier: 12.9.0
-        version: 12.9.0
       camoufox-js:
-        specifier: ^0.10.2
-        version: 0.10.2(playwright-core@1.59.1)
+        specifier: ^0.9.3
+        version: 0.9.3(playwright-core@1.59.1)
       playwright-core:
         specifier: ^1.59.1
         version: 1.59.1
@@ -266,16 +303,26 @@ packages:
     resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/generator@8.0.0-rc.3':
-    resolution: {integrity: sha512-em37/13/nR320G4jab/nIIHZgc2Wz2y/D39lxnTyxB4/D/omPQncl/lSdlnJY1OhQcRGugTSIF2l/69o31C9dA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
+  '@babel/helper-annotate-as-pure@7.27.3':
+    resolution: {integrity: sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/helper-compilation-targets@7.28.6':
     resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-create-class-features-plugin@7.28.6':
+    resolution: {integrity: sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
   '@babel/helper-globals@7.28.0':
     resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-member-expression-to-functions@7.28.5':
+    resolution: {integrity: sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-module-imports@7.28.6':
@@ -288,21 +335,31 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
+  '@babel/helper-optimise-call-expression@7.27.1':
+    resolution: {integrity: sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-plugin-utils@7.28.6':
+    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-replace-supers@7.28.6':
+    resolution: {integrity: sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
+    resolution: {integrity: sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@8.0.0-rc.3':
-    resolution: {integrity: sha512-AmwWFx1m8G/a5cXkxLxTiWl+YEoWuoFLUCwqMlNuWO1tqAYITQAbCRPUkyBHv1VOFgfjVOqEj6L3u15J5ZCzTA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@8.0.0-rc.3':
-    resolution: {integrity: sha512-8AWCJ2VJJyDFlGBep5GpaaQ9AAaE/FjAcrqI7jyssYhtL7WGV0DOKpJsQqM037xDbpRLHXsY8TwU7zDma7coOw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
 
   '@babel/helper-validator-option@7.27.1':
     resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
@@ -317,10 +374,83 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/parser@8.0.0-rc.3':
-    resolution: {integrity: sha512-B20dvP3MfNc/XS5KKCHy/oyWl5IA6Cn9YjXRdDlCjNmUFrjvLXMNUfQq/QUy9fnG2gYkKKcrto2YaF9B32ToOQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
+  '@babel/plugin-syntax-flow@7.28.6':
+    resolution: {integrity: sha512-D+OrJumc9McXNEBI/JmFnc/0uCM2/Y3PEBG3gfV3QIYkKv5pvnpzFrl1kYCrcHJP8nOeFB/SHi1IHz29pNGuew==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-jsx@7.28.6':
+    resolution: {integrity: sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-typescript@7.28.6':
+    resolution: {integrity: sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-class-properties@7.28.6':
+    resolution: {integrity: sha512-dY2wS3I2G7D697VHndN91TJr8/AAfXQNt5ynCTI/MpxMsSzHp+52uNivYT5wCPax3whc47DR8Ba7cmlQMg24bw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-flow-strip-types@7.27.1':
+    resolution: {integrity: sha512-G5eDKsu50udECw7DL2AcsysXiQyB7Nfg521t2OAJ4tbfTJ27doHLeF/vlI1NZGlLdbb/v+ibvtL1YBQqYOwJGg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-modules-commonjs@7.28.6':
+    resolution: {integrity: sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-nullish-coalescing-operator@7.28.6':
+    resolution: {integrity: sha512-3wKbRgmzYbw24mDJXT7N+ADXw8BC/imU9yo9c9X9NKaLF1fW+e5H1U5QjMUBe4Qo4Ox/o++IyUkl1sVCLgevKg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-optional-chaining@7.28.6':
+    resolution: {integrity: sha512-A4zobikRGJTsX9uqVFdafzGkqD30t26ck2LmOzAuLL8b2x6k3TIqRiT2xVvA9fNmFeTX484VpsdgmKNA0bS23w==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-private-methods@7.28.6':
+    resolution: {integrity: sha512-piiuapX9CRv7+0st8lmuUlRSmX6mBcVeNQ1b4AYzJxfCMuBfB0vBXDiGSmm03pKJw1v6cZ8KSeM+oUnM6yAExg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-typescript@7.28.6':
+    resolution: {integrity: sha512-0YWL2RFxOqEm9Efk5PvreamxPME8OyY0wM5wh5lHjF+VtVhdneCWGzZeSqzOfiobVqQaNCd2z0tQvnI9DaPWPw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/preset-flow@7.27.1':
+    resolution: {integrity: sha512-ez3a2it5Fn6P54W8QkbfIyyIbxlXvcxyWHHvno1Wg0Ej5eiJY5hBb8ExttoIOJJk7V2dZE6prP7iby5q2aQ0Lg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/preset-typescript@7.28.5':
+    resolution: {integrity: sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/register@7.28.6':
+    resolution: {integrity: sha512-pgcbbEl/dWQYb6L6Yew6F94rdwygfuv+vJ/tXfwIOYAfPB6TNWpXUMEtEq3YuTeHRdvMIhvz13bkT9CNaS+wqA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
 
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
@@ -333,10 +463,6 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/types@8.0.0-rc.3':
-    resolution: {integrity: sha512-mOm5ZrYmphGfqVWoH5YYMTITb3cDXsFgmvFlvkvWDMsR9X8RFnt7a0Wb6yNIdoFsiMO9WjYLq+U/FMtqIYAF8Q==}
-    engines: {node: ^20.19.0 || >=22.12.0}
 
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
@@ -604,49 +730,11 @@ packages:
       '@noble/hashes':
         optional: true
 
-  '@graphql-tools/merge@9.1.8':
-    resolution: {integrity: sha512-25V7WDrODo1cPrmuUCrqf5qlMA4a/Ow4aHaqJ1MnTUaluwsV3UiqzCHWux3HSLb0H63mkoZiuOrU5xJhxRcoCg==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-
-  '@graphql-tools/schema@10.0.32':
-    resolution: {integrity: sha512-kJ1Qn20MPnlaEVH37639E6rzQ1tEtr6XTUhNdR4EKydl+FijtLhWX2WLZbGnvrYuG8XUcMxsZU9mRRYYNvK02w==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-
-  '@graphql-tools/utils@11.0.1':
-    resolution: {integrity: sha512-pNyCOb95ab/z3zkkiPwIPYxigX7IcpyFVcgD1XACDEvg/7yGnKCESx3k/XHEeneKYx/aWKGzEh/uuf6M6Q8HOw==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-
-  '@graphql-typed-document-node/core@3.2.0':
-    resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
-    peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-
-  '@hono/node-server@1.19.13':
-    resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
+  '@hono/node-server@1.19.11':
+    resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: '>=4.12.14'
-
-  '@httptoolkit/httpolyglot@3.0.1':
-    resolution: {integrity: sha512-fU9psZBRc49PfdrxFZ8W19SwVQ4+rrc0EYVxmy7H41y6/elaIu5p68wly4uLVt1DPD0K92MdN65GqP3N1ofZKg==}
-    engines: {node: '>=20.0.0'}
-
-  '@httptoolkit/subscriptions-transport-ws@0.11.2':
-    resolution: {integrity: sha512-YB+gYYVjgYUeJrGkfS91ABeNWCFU7EVcn9Cflf2UXjsIiPJEI6yPxujPcjKv9wIJpM+33KQW/qVEmc+BdIDK2w==}
-    peerDependencies:
-      graphql: ^15.7.2 || ^16.0.0
-
-  '@httptoolkit/util@0.1.9':
-    resolution: {integrity: sha512-MRRf7UAHcb/bXfytFDmuCo+XRH6HqxXpQpTMT8KUd95YCLDiofPOBE+2SV3M6rG4YYeEf3WxNzQiidn3qo1akQ==}
-
-  '@httptoolkit/websocket-stream@6.0.1':
-    resolution: {integrity: sha512-A0NOZI+Glp3Xgcz6Na7i7o09+/+xm2m0UCU8gdtM2nIv6/cjLmhMZMqehSpTlgbx9omtLmV8LVqOskPEyWnmZQ==}
+      hono: 4.12.7
 
   '@huggingface/jinja@0.5.7':
     resolution: {integrity: sha512-OosMEbF/R6zkKNNzqhI7kvKYCpo1F0UeIv46/h4D4UjVEKKd6k3TiV8sgu6fkreX4lbBiRI+lZG8UnXnqVQmEQ==}
@@ -848,6 +936,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@jsoverson/shift-codegen@7.0.0':
+    resolution: {integrity: sha512-fBklFErIYirpd3IufjLYxoijJTjIYI9zqN3irxrNE6XvEPuU4hkPBqFsPwFWJvepSsGvqV4k5Cd8fky8Axya4w==}
+
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
     engines: {node: '>=18'}
@@ -864,127 +955,139 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
 
-  '@oxfmt/binding-android-arm-eabi@0.46.0':
-    resolution: {integrity: sha512-b1doV4WRcJU+BESSlCvCjV+5CEr/T6h0frArAdV26Nir+gGNFNaylvDiiMPfF1pxeV0txZEs38ojzJaxBYg+ng==}
+  '@oxfmt/binding-android-arm-eabi@0.44.0':
+    resolution: {integrity: sha512-5UvghMd9SA/yvKTWCAxMAPXS1d2i054UeOf4iFjZjfayTwCINcC3oaSXjtbZfCaEpxgJod7XiOjTtby5yEv/BQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
 
-  '@oxfmt/binding-android-arm64@0.46.0':
-    resolution: {integrity: sha512-v6+HhjsoV3GO0u2u9jLSAZrvWfTraDxKofUIQ7/ktS7tzS+epVsxdHmeM+XxuNcAY/nWxxU1Sg4JcGTNRXraBA==}
+  '@oxfmt/binding-android-arm64@0.44.0':
+    resolution: {integrity: sha512-IVudM1BWfvrYO++Khtzr8q9n5Rxu7msUvoFMqzGJVdX7HfUXUDHwaH2zHZNB58svx2J56pmCUzophyaPFkcG/A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@oxfmt/binding-darwin-arm64@0.46.0':
-    resolution: {integrity: sha512-3eeooJGrqGIlI5MyryDZsAcKXSmKIgAD4yYtfRrRJzXZ0UTFZtiSveIur56YPrGMYZwT4XyVhHsMqrNwr1XeFA==}
+  '@oxfmt/binding-darwin-arm64@0.44.0':
+    resolution: {integrity: sha512-eWCLAIKAHfx88EqEP1Ga2yz7qVcqDU5lemn4xck+07bH182hDdprOHjbogyk0In1Djys3T0/pO2JepFnRJ41Mg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxfmt/binding-darwin-x64@0.46.0':
-    resolution: {integrity: sha512-QG8BDM0CXWbu84k2SKmCqfEddPQPFiBicwtYnLqHRWZZl57HbtOLRMac/KTq2NO4AEc4ICCBpFxJIV9zcqYfkQ==}
+  '@oxfmt/binding-darwin-x64@0.44.0':
+    resolution: {integrity: sha512-eHTBznHLM49++dwz07MblQ2cOXyIgeedmE3Wgy4ptUESj38/qYZyRi1MPwC9olQJWssMeY6WI3UZ7YmU5ggvyQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@oxfmt/binding-freebsd-x64@0.46.0':
-    resolution: {integrity: sha512-9DdCqS/n2ncu/Chazvt3cpgAjAmIGQDz7hFKSrNItMApyV/Ja9mz3hD4JakIE3nS8PW9smEbPWnb389QLBY4nw==}
+  '@oxfmt/binding-freebsd-x64@0.44.0':
+    resolution: {integrity: sha512-jLMmbj0u0Ft43QpkUVr/0v1ZfQCGWAvU+WznEHcN3wZC/q6ox7XeSJtk9P36CCpiDSUf3sGnzbIuG1KdEMEDJQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxfmt/binding-linux-arm-gnueabihf@0.46.0':
-    resolution: {integrity: sha512-Dgs7VeE2jT0LHMhw6tPEt0xQYe54kBqHEovmWsv4FVQlegCOvlIJNx0S8n4vj8WUtpT+Z6BD2HhKJPLglLxvZg==}
+  '@oxfmt/binding-linux-arm-gnueabihf@0.44.0':
+    resolution: {integrity: sha512-n+A/u/ByK1qV8FVGOwyaSpw5NPNl0qlZfgTBqHeGIqr8Qzq1tyWZ4lAaxPoe5mZqE3w88vn3+jZtMxriHPE7tg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxfmt/binding-linux-arm-musleabihf@0.46.0':
-    resolution: {integrity: sha512-Zxn3adhTH13JKnU4xXJj8FeEfF680XjXh3gSShKl57HCMBRde2tUJTgogV/1MSHA80PJEVrDa7r66TLVq3Ia7Q==}
+  '@oxfmt/binding-linux-arm-musleabihf@0.44.0':
+    resolution: {integrity: sha512-5eax+FkxyCqAi3Rw0mrZFr7+KTt/XweFsbALR+B5ljWBLBl8nHe4ADrUnb1gLEfQCJLl+Ca5FIVD4xEt95AwIw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxfmt/binding-linux-arm64-gnu@0.46.0':
-    resolution: {integrity: sha512-+TWipjrgVM8D7aIdDD0tlr3teLTTvQTn7QTE5BpT10H1Fj82gfdn9X6nn2sDgx/MepuSCfSnzFNJq2paLL0OiA==}
+  '@oxfmt/binding-linux-arm64-gnu@0.44.0':
+    resolution: {integrity: sha512-58l8JaHxSGOmOMOG2CIrNsnkRJAj0YcHQCmvNACniOa/vd1iRHhlPajczegzS5jwMENlqgreyiTR9iNlke8qCw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-arm64-musl@0.46.0':
-    resolution: {integrity: sha512-aAUPBWJ1lGwwnxZUEDLJ94+Iy6MuwJwPxUgO4sCA5mEEyDk7b+cDQ+JpX1VR150Zoyd+D49gsrUzpUK5h587Eg==}
+  '@oxfmt/binding-linux-arm64-musl@0.44.0':
+    resolution: {integrity: sha512-AlObQIXyVRZ96LbtVljtFq0JqH5B92NU+BQeDFrXWBUWlCKAM0wF5GLfIhCLT5kQ3Sl+U0YjRJ7Alqj5hGQaCg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@oxfmt/binding-linux-ppc64-gnu@0.46.0':
-    resolution: {integrity: sha512-ufBCJukyFX/UDrokP/r6BGDoTInnsDs7bxyzKAgMiZlt2Qu8GPJSJ6Zm6whIiJzKk0naxA8ilwmbO1LMw6Htxw==}
+  '@oxfmt/binding-linux-ppc64-gnu@0.44.0':
+    resolution: {integrity: sha512-YcFE8/q/BbrCiIiM5piwbkA6GwJc5QqhMQp2yDrqQ2fuVkZ7CInb1aIijZ/k8EXc72qXMSwKpVlBv1w/MsGO/A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-riscv64-gnu@0.46.0':
-    resolution: {integrity: sha512-eqtlC2YmPqjun76R1gVfGLuKWx7NuEnLEAudZ7n6ipSKbCZTqIKSs1b5Y8K/JHZsRpLkeSmAAjig5HOIg8fQzQ==}
+  '@oxfmt/binding-linux-riscv64-gnu@0.44.0':
+    resolution: {integrity: sha512-eOdzs6RqkRzuqNHUX5C8ISN5xfGh4xDww8OEd9YAmc3OWN8oAe5bmlIqQ+rrHLpv58/0BuU48bxkhnIGjA/ATQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-riscv64-musl@0.46.0':
-    resolution: {integrity: sha512-yccVOO2nMXkQLGgy0He3EQEwKD7NF0zEk+/OWmroznkqXyJdN6bfK0LtNnr6/14Bh3FjpYq7bP33l/VloCnxpA==}
+  '@oxfmt/binding-linux-riscv64-musl@0.44.0':
+    resolution: {integrity: sha512-YBgNTxntD/QvlFUfgvh8bEdwOhXiquX8gaofZJAwYa/Xp1S1DQrFVZEeck7GFktr24DztsSp8N8WtWCBwxs0Hw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@oxfmt/binding-linux-s390x-gnu@0.46.0':
-    resolution: {integrity: sha512-aAf7fG23OQCey6VRPj9IeCraoYtpgtx0ZyJ1CXkPyT1wjzBE7c3xtuxHe/AdHaJfVVb/SXpSk8Gl1LzyQupSqw==}
+  '@oxfmt/binding-linux-s390x-gnu@0.44.0':
+    resolution: {integrity: sha512-GLIh1R6WHWshl/i4QQDNgj0WtT25aRO4HNUWEoitxiywyRdhTFmFEYT2rXlcl9U6/26vhmOqG5cRlMLG3ocaIA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-x64-gnu@0.46.0':
-    resolution: {integrity: sha512-q0JPsTMyJNjYrBvYFDz4WbVsafNZaPCZv4RnFypRotLqpKROtBZcEaXQW4eb9YmvLU3NckVemLJnzkSZSdmOxw==}
+  '@oxfmt/binding-linux-x64-gnu@0.44.0':
+    resolution: {integrity: sha512-gZOpgTlOsLcLfAF9qgpTr7FIIFSKnQN3hDf/0JvQ4CIwMY7h+eilNjxq/CorqvYcEOu+LRt1W4ZS7KccEHLOdA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@oxfmt/binding-linux-x64-musl@0.46.0':
-    resolution: {integrity: sha512-7LsLY9Cw57GPkhSR+duI3mt9baRczK/DtHYSldQ4BEU92da9igBQNl4z7Vq5U9NNPsh1FmpKvv1q9WDtiUQR1A==}
+  '@oxfmt/binding-linux-x64-musl@0.44.0':
+    resolution: {integrity: sha512-1CyS9JTB+pCUFYFI6pkQGGZaT/AY5gnhHVrQQLhFba6idP9AzVYm1xbdWfywoldTYvjxQJV6x4SuduCIfP3W+A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@oxfmt/binding-openharmony-arm64@0.46.0':
-    resolution: {integrity: sha512-lHiBOz8Duaku7JtRNLlps3j++eOaICPZSd8FCVmTDM4DFOPT71Bjn7g6iar1z7StXlKRweUKxWUs4sA+zWGDXg==}
+  '@oxfmt/binding-openharmony-arm64@0.44.0':
+    resolution: {integrity: sha512-bmEv70Ak6jLr1xotCbF5TxIKjsmQaiX+jFRtnGtfA03tJPf6VG3cKh96S21boAt3JZc+Vjx8PYcDuLj39vM2Pw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxfmt/binding-win32-arm64-msvc@0.46.0':
-    resolution: {integrity: sha512-/5ktYUliP89RhgC37DBH1x20U5zPSZMy3cMEcO0j3793rbHP9MWsknBwQB6eozRzWmYrh0IFM/p20EbPvDlYlg==}
+  '@oxfmt/binding-win32-arm64-msvc@0.44.0':
+    resolution: {integrity: sha512-yWzB+oCpSnP/dmw85eFLAT5o35Ve5pkGS2uF/UCISpIwDqf1xa7OpmtomiqY/Vzg8VyvMbuf6vroF2khF/+1Vg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@oxfmt/binding-win32-ia32-msvc@0.46.0':
-    resolution: {integrity: sha512-3WTnoiuIr8XvV0DIY7SN+1uJSwKf4sPpcbHfobcRT9JutGcLaef/miyBB87jxd3aqH+mS0+G5lsgHuXLUwjjpQ==}
+  '@oxfmt/binding-win32-ia32-msvc@0.44.0':
+    resolution: {integrity: sha512-TcWpo18xEIE3AmIG2kpr3kz5IEhQgnx0lazl2+8L+3eTopOAUevQcmlr4nhguImNWz0OMeOZrYZOhJNCf16nlQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
-  '@oxfmt/binding-win32-x64-msvc@0.46.0':
-    resolution: {integrity: sha512-IXxiQpkYnOwNfP23vzwSfhdpxJzyiPTY7eTn6dn3DsriKddESzM8i6kfq9R7CD/PUJwCvQT22NgtygBeug3KoA==}
+  '@oxfmt/binding-win32-x64-msvc@0.44.0':
+    resolution: {integrity: sha512-oj8aLkPJZppIM4CMQNsyir9ybM1Xw/CfGPTSsTnzpVGyljgfbdP0EVUlURiGM0BDrmw5psQ6ArmGCcUY/yABaQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -1111,40 +1214,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@peculiar/asn1-cms@2.6.1':
-    resolution: {integrity: sha512-vdG4fBF6Lkirkcl53q6eOdn3XYKt+kJTG59edgRZORlg/3atWWEReRCx5rYE1ZzTTX6vLK5zDMjHh7vbrcXGtw==}
-
-  '@peculiar/asn1-csr@2.6.1':
-    resolution: {integrity: sha512-WRWnKfIocHyzFYQTka8O/tXCiBquAPSrRjXbOkHbO4qdmS6loffCEGs+rby6WxxGdJCuunnhS2duHURhjyio6w==}
-
-  '@peculiar/asn1-ecc@2.6.1':
-    resolution: {integrity: sha512-+Vqw8WFxrtDIN5ehUdvlN2m73exS2JVG0UAyfVB31gIfor3zWEAQPD+K9ydCxaj3MLen9k0JhKpu9LqviuCE1g==}
-
-  '@peculiar/asn1-pfx@2.6.1':
-    resolution: {integrity: sha512-nB5jVQy3MAAWvq0KY0R2JUZG8bO/bTLpnwyOzXyEh/e54ynGTatAR+csOnXkkVD9AFZ2uL8Z7EV918+qB1qDvw==}
-
-  '@peculiar/asn1-pkcs8@2.6.1':
-    resolution: {integrity: sha512-JB5iQ9Izn5yGMw3ZG4Nw3Xn/hb/G38GYF3lf7WmJb8JZUydhVGEjK/ZlFSWhnlB7K/4oqEs8HnfFIKklhR58Tw==}
-
-  '@peculiar/asn1-pkcs9@2.6.1':
-    resolution: {integrity: sha512-5EV8nZoMSxeWmcxWmmcolg22ojZRgJg+Y9MX2fnE2bGRo5KQLqV5IL9kdSQDZxlHz95tHvIq9F//bvL1OeNILw==}
-
-  '@peculiar/asn1-rsa@2.6.1':
-    resolution: {integrity: sha512-1nVMEh46SElUt5CB3RUTV4EG/z7iYc7EoaDY5ECwganibQPkZ/Y2eMsTKB/LeyrUJ+W/tKoD9WUqIy8vB+CEdA==}
-
-  '@peculiar/asn1-schema@2.6.0':
-    resolution: {integrity: sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg==}
-
-  '@peculiar/asn1-x509-attr@2.6.1':
-    resolution: {integrity: sha512-tlW6cxoHwgcQghnJwv3YS+9OO1737zgPogZ+CgWRUK4roEwIPzRH4JEiG770xe5HX2ATfCpmX60gurfWIF9dcQ==}
-
-  '@peculiar/asn1-x509@2.6.1':
-    resolution: {integrity: sha512-O9jT5F1A2+t3r7C4VT7LYGXqkGLK7Kj1xFpz7U0isPrubwU5PbDoyYtx6MiGst29yq7pXN5vZbQFKRCP+lLZlA==}
-
-  '@peculiar/x509@1.14.3':
-    resolution: {integrity: sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==}
-    engines: {node: '>=20.0.0'}
-
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
 
@@ -1179,9 +1248,6 @@ packages:
     resolution: {integrity: sha512-iPpnFpX25gKIVsHsqVjHV+/GzW36xPgsscWkCnrrETndcdxNsXLdCrTwhkCJNR/FGWr122dJUBeyV4niz/j3TA==}
     engines: {node: '>=18'}
     hasBin: true
-
-  '@quansync/fs@1.0.0':
-    resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
@@ -1281,6 +1347,144 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.17':
     resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
 
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    resolution: {integrity: sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    resolution: {integrity: sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    resolution: {integrity: sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    resolution: {integrity: sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    resolution: {integrity: sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    resolution: {integrity: sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    resolution: {integrity: sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    resolution: {integrity: sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
+    cpu: [x64]
+    os: [win32]
+
   '@shikijs/core@2.5.0':
     resolution: {integrity: sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==}
 
@@ -1330,23 +1534,17 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
-  '@types/cors@2.8.19':
-    resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
-
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/escodegen@0.0.10':
+    resolution: {integrity: sha512-IVvcNLEFbiL17qiGRGzyfx/u9K6lA5w6wcQSIgv2h4JG3ZAFIY1Be9ITTSPuARIxRpzW54s8OvcF6PdonBbDzg==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
-
-  '@types/jsdom@28.0.1':
-    resolution: {integrity: sha512-GJq2QE4TAZ5ajSoCasn5DOFm8u1mI3tIFvM5tIq3W5U/RTB6gsHwc6Yhpl91X9VSDOUVblgXmG+2+sSvFQrdlw==}
-
-  '@types/jsesc@2.5.1':
-    resolution: {integrity: sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==}
 
   '@types/linkify-it@5.0.0':
     resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
@@ -1363,17 +1561,11 @@ packages:
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
 
-  '@types/tough-cookie@4.0.5':
-    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
-
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@types/web-bluetooth@0.0.21':
     resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
-
-  '@types/ws@8.18.1':
-    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
@@ -1517,10 +1709,6 @@ packages:
   '@vueuse/shared@12.8.2':
     resolution: {integrity: sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==}
 
-  '@whatwg-node/promise-helpers@1.3.2':
-    resolution: {integrity: sha512-Nst5JdK47VIl9UcGwtv2Rcgyn5lWtZ0/mhRQ4G8NN2isxpq2TO30iqHzmwoJycjWuyUfg3GFXqP/gFHXeV57IA==}
-    engines: {node: '>=16.0.0'}
-
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -1560,35 +1748,34 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
-  ansi-styles@6.2.3:
-    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
-    engines: {node: '>=12'}
+  anymatch@3.1.3:
+    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
+    engines: {node: '>= 8'}
 
-  ansis@4.2.0:
-    resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
-    engines: {node: '>=14'}
-
-  asn1js@3.0.7:
-    resolution: {integrity: sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ==}
-    engines: {node: '>=12.0.0'}
+  array-union@2.1.0:
+    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
+    engines: {node: '>=8'}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
-  ast-kit@3.0.0-beta.1:
-    resolution: {integrity: sha512-trmleAnZ2PxN/loHWVhhx1qeOHSRXq4TDsBBxq3GqeJitfk3+jTQ+v/C1km/KYq9M7wKqCewMh+/NAvVH7m+bw==}
-    engines: {node: '>=20.19.0'}
-
   ast-types@0.13.4:
     resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
+    engines: {node: '>=4'}
+
+  ast-types@0.16.1:
+    resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
 
   ast-v8-to-istanbul@1.0.0:
     resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
-  async-mutex@0.5.0:
-    resolution: {integrity: sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==}
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  axios@1.15.0:
+    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
 
   b4a@1.8.0:
     resolution: {integrity: sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==}
@@ -1597,9 +1784,6 @@ packages:
     peerDependenciesMeta:
       react-native-b4a:
         optional: true
-
-  backo2@1.0.2:
-    resolution: {integrity: sha512-zj6Z6M7Eq+PBZ7PQxl5NT665MvJdAkzp0f60nAJ+sLaSCBPMwVak5ZegFbgVCzFcCJTKFoMizvM5Ld7+JrRJHA==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -1646,10 +1830,6 @@ packages:
   bare-url@2.4.0:
     resolution: {integrity: sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==}
 
-  base64-arraybuffer@1.0.2:
-    resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
-    engines: {node: '>= 0.6.0'}
-
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -1658,25 +1838,26 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  basic-ftp@5.3.0:
-    resolution: {integrity: sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==}
+  basic-ftp@5.2.1:
+    resolution: {integrity: sha512-0yaL8JdxTknKDILitVpfYfV2Ob6yb3udX/hK97M7I3jOeznBNxQPtVvTUtnhUkyHlxFWyr5Lvknmgzoc7jf+1Q==}
     engines: {node: '>=10.0.0'}
 
-  better-sqlite3@12.9.0:
-    resolution: {integrity: sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==}
+  better-sqlite3@12.8.0:
+    resolution: {integrity: sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==}
     engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
 
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
+  binary-extensions@2.3.0:
+    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
+    engines: {node: '>=8'}
 
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
   birpc@2.9.0:
     resolution: {integrity: sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==}
-
-  birpc@4.0.0:
-    resolution: {integrity: sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==}
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
@@ -1696,9 +1877,9 @@ packages:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
 
-  brotli-wasm@3.0.1:
-    resolution: {integrity: sha512-U3K72/JAi3jITpdhZBqzSUq+DUY697tLxOuFXB+FpAE/Ug+5C3VZrv4uA674EUZHxNAuQ9wETXNqQkxZD6oL4A==}
-    engines: {node: '>=v18.0.0'}
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
 
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
@@ -1708,24 +1889,15 @@ packages:
   buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
-
-  bundle-name@4.1.0:
-    resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
-    engines: {node: '>=18'}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
-
-  cac@7.0.0:
-    resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
-    engines: {node: '>=20.19.0'}
-
-  cacheable-lookup@6.1.0:
-    resolution: {integrity: sha512-KJ/Dmo1lDDhmW2XDPMo+9oiy/CeqosPguPCrgcVzKyZrL6pM1gU2GmPY/xo6OQPTUaA/c0kwHuywB4E6nmT9ww==}
-    engines: {node: '>=10.6.0'}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -1739,8 +1911,8 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
-  camoufox-js@0.10.2:
-    resolution: {integrity: sha512-rmOQsSGexkZyNPs7Gj91lxsp6USlmMcDWUKZNYh2Uh54Dg49CWL1nBps2dZhPuxUoECKk6Tw0H4al3o1a6WE1Q==}
+  camoufox-js@0.9.3:
+    resolution: {integrity: sha512-HKdCaUudkgJBzZZ9HxDu0JVmRFKWySnQrhhsqBGnEEuGHzsCs+Bon0bCrEePZ4Ax0BlycMOr/zxKq6kSu516sw==}
     engines: {node: '>= 20'}
     hasBin: true
     peerDependencies:
@@ -1756,11 +1928,19 @@ packages:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
 
   character-entities-legacy@3.0.0:
     resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  chokidar@3.6.0:
+    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
+    engines: {node: '>= 8.10.0'}
 
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
@@ -1770,17 +1950,25 @@ packages:
     peerDependencies:
       devtools-protocol: '*'
 
+  cli-cursor@5.0.0:
+    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
+    engines: {node: '>=18'}
+
   cli-progress@3.12.0:
     resolution: {integrity: sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==}
     engines: {node: '>=4'}
+
+  cli-spinners@3.4.0:
+    resolution: {integrity: sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==}
+    engines: {node: '>=18.20'}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
 
-  cliui@9.0.1:
-    resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
-    engines: {node: '>=20'}
+  clone-deep@4.0.1:
+    resolution: {integrity: sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==}
+    engines: {node: '>=6'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -1788,6 +1976,10 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
@@ -1804,13 +1996,8 @@ packages:
     resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
     engines: {node: ^12.20.0 || >=14}
 
-  common-tags@1.8.2:
-    resolution: {integrity: sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==}
-    engines: {node: '>=4.0.0'}
-
-  connect@3.7.0:
-    resolution: {integrity: sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==}
-    engines: {node: '>= 0.10.0'}
+  commondir@1.0.1:
+    resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
 
   content-disposition@1.1.0:
     resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
@@ -1835,9 +2022,6 @@ packages:
     resolution: {integrity: sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==}
     engines: {node: '>=18'}
 
-  core-util-is@1.0.3:
-    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
-
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
@@ -1846,10 +2030,6 @@ packages:
     resolution: {integrity: sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==}
     engines: {node: '>=20'}
     hasBin: true
-
-  cross-inspect@1.0.1:
-    resolution: {integrity: sha512-Pcw1JTvZLSJH83iiGWt6fRcT+BjZlCDRVwYLbUcHzv/CRpB7r0MlSrGbIyQvVSNyGnbt7G4AXuyCiDR3POvZ1A==}
-    engines: {node: '>=16.0.0'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1869,14 +2049,6 @@ packages:
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-
-  debug@2.6.9:
-    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
 
   debug@4.3.7:
     resolution: {integrity: sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==}
@@ -1907,32 +2079,21 @@ packages:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
 
-  default-browser-id@5.0.1:
-    resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
-    engines: {node: '>=18'}
-
-  default-browser@5.5.0:
-    resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
-    engines: {node: '>=18'}
-
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
     engines: {node: '>= 0.4'}
-
-  define-lazy-prop@3.0.0:
-    resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
-    engines: {node: '>=12'}
 
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
-  defu@6.1.7:
-    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
-
   degenerator@5.0.1:
     resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
     engines: {node: '>= 14'}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -1941,10 +2102,6 @@ packages:
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
-
-  destroyable-server@1.1.1:
-    resolution: {integrity: sha512-7tjgU/99QVuYSqkMXr6XdQSvXj+8TjC9NiRVWNSyGytxklZ88m+qcSvWTJ3VysE3I9wurph7dTciLEEj8aUlaQ==}
-    engines: {node: '>=12.0.0'}
 
   detect-europe-js@0.1.2:
     resolution: {integrity: sha512-lgdERlL3u0aUdHocoouzT10d9I89VVhk0qNRmll7mXdGfJT1/wqZ2ZLA4oJAjeACPY5fT1wsbq2AT+GkuInsow==}
@@ -1962,6 +2119,10 @@ packages:
   devtools-protocol@0.0.1439962:
     resolution: {integrity: sha512-jJF48UdryzKiWhJ1bLKr7BFWUQCEIT5uCNbDLqkQJBtkFxYzILJH44WN0PDKMIlGDN7Utb8vyUY85C3w4R/t2g==}
 
+  dir-glob@3.0.1:
+    resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
+    engines: {node: '>=8'}
+
   dot-prop@6.0.1:
     resolution: {integrity: sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==}
     engines: {node: '>=10'}
@@ -1970,21 +2131,9 @@ packages:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
     engines: {node: '>=12'}
 
-  dts-resolver@2.1.3:
-    resolution: {integrity: sha512-bihc7jPC90VrosXNzK0LTE2cuLP6jr0Ro8jk+kMugHReJVLIpHz/xadeq3MhuwyO4TD4OA3L1Q8pBBFRc08Tsw==}
-    engines: {node: '>=20.19.0'}
-    peerDependencies:
-      oxc-resolver: '>=11.0.0'
-    peerDependenciesMeta:
-      oxc-resolver:
-        optional: true
-
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
-
-  duplexify@3.7.1:
-    resolution: {integrity: sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==}
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
@@ -1995,19 +2144,8 @@ packages:
   emoji-regex-xs@1.0.0:
     resolution: {integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==}
 
-  emoji-regex@10.6.0:
-    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
-
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
-
-  empathic@2.0.0:
-    resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
-    engines: {node: '>=14'}
-
-  encodeurl@1.0.2:
-    resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
-    engines: {node: '>= 0.8'}
 
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
@@ -2015,10 +2153,6 @@ packages:
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
-
-  entities@6.0.1:
-    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
-    engines: {node: '>=0.12'}
 
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
@@ -2041,6 +2175,10 @@ packages:
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
   es6-error@4.1.1:
@@ -2072,6 +2210,10 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  estraverse@4.2.0:
+    resolution: {integrity: sha512-VHvyaGnJy+FuGfcfaM7W7OZw4mQiKW73jPHwQXx2VnMSUBajYmytOT5sKEfsBvNPtGX6YDwcrGDz2eocoHg0JA==}
+    engines: {node: '>=0.10.0'}
+
   estraverse@5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
@@ -2082,6 +2224,10 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  esutils@2.0.2:
+    resolution: {integrity: sha512-UUPPULqkyAV+M3Shodis7l8D+IyX6V8SbaBnTb449jf3fMTd8+UOZI1Q70NbZVOQkcR91yYgdHsJiMMMVmYshg==}
+    engines: {node: '>=0.10.0'}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -2089,9 +2235,6 @@ packages:
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
-
-  eventemitter3@3.1.2:
-    resolution: {integrity: sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==}
 
   events-universal@1.0.1:
     resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
@@ -2133,11 +2276,15 @@ packages:
   fast-fifo@1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
-  fast-json-patch@3.1.1:
-    resolution: {integrity: sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==}
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
 
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
   fd-slicer@1.1.0:
     resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
@@ -2154,13 +2301,21 @@ packages:
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
-  finalhandler@1.1.2:
-    resolution: {integrity: sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==}
-    engines: {node: '>= 0.8'}
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
 
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
+
+  find-cache-dir@2.1.0:
+    resolution: {integrity: sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==}
+    engines: {node: '>=6'}
+
+  find-up@3.0.0:
+    resolution: {integrity: sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==}
+    engines: {node: '>=6'}
 
   fingerprint-generator@2.1.82:
     resolution: {integrity: sha512-5Z/yCKW324pMyMarpIKe/QPdkrFWKNJv3ktdU+fXHri80+HAwNE6QhMvEvsMkK9Q8DeCXZlpPHV77UBa1nFb4A==}
@@ -2169,8 +2324,25 @@ packages:
   flatbuffers@25.9.23:
     resolution: {integrity: sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==}
 
+  flow-parser@0.309.0:
+    resolution: {integrity: sha512-poYRskeIXiHsE19Fb9sRE/CV7PYOq21j3lS5vKr27ujFBvSAhmCbbilAonJ0/u0Uai+Xgyq30/twHQeQc2Ngiw==}
+    engines: {node: '>=0.4.0'}
+
   focus-trap@7.8.0:
     resolution: {integrity: sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==}
+
+  follow-redirects@1.15.11:
+    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -2210,10 +2382,6 @@ packages:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
 
-  get-port@7.2.0:
-    resolution: {integrity: sha512-afP4W205ONCuMoPBqcR6PSXnzX35KTcJygfJfcp+QY+uwm3p20p1YczWXhlICIzGMCxYBQcySEcOgsJcrkyobg==}
-    engines: {node: '>=16'}
-
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
@@ -2235,6 +2403,10 @@ packages:
   github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
@@ -2247,33 +2419,27 @@ packages:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
 
+  globby@11.1.0:
+    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
+    engines: {node: '>=10'}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
 
-  graphql-http@1.22.4:
-    resolution: {integrity: sha512-OC3ucK988teMf+Ak/O+ZJ0N2ukcgrEurypp8ePyJFWq83VzwRAmHxxr+XxrMpxO/FIwI4a7m/Fzv3tWGJv0wPA==}
-    engines: {node: '>=12'}
-    peerDependencies:
-      graphql: '>=0.11 <=16'
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
-  graphql-subscriptions@2.0.0:
-    resolution: {integrity: sha512-s6k2b8mmt9gF9pEfkxsaO1lTxaySfKoEJzEfmwguBbQ//Oq23hIXCfR1hm4kdh5hnR20RdwB+s3BCb+0duHSZA==}
-    peerDependencies:
-      graphql: ^15.7.2 || ^16.0.0
-
-  graphql-tag@2.12.6:
-    resolution: {integrity: sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      graphql: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
-
-  graphql@15.10.2:
-    resolution: {integrity: sha512-1PRqdDPAmViWr4h1GVBT8RoPZfWSGZa7kDzleTilOfVIslsgf+cia3Nl95v1KDmR4iERPaT7WzQ+tN4MJmbg3w==}
-    engines: {node: '>= 10.x'}
+  groq-sdk@1.1.2:
+    resolution: {integrity: sha512-CZO0XUQQDhn43ri1+lZHxZKpb+bGutgTvFmCJtooexiitGmPqhm1hntOT3nCoaq07e+OpeokVnfUs0i/oQuUaQ==}
+    hasBin: true
 
   guid-typescript@1.0.9:
     resolution: {integrity: sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==}
+
+  has-flag@3.0.0:
+    resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
+    engines: {node: '>=4'}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -2284,6 +2450,10 @@ packages:
 
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
   hasown@2.0.2:
@@ -2300,15 +2470,12 @@ packages:
     resolution: {integrity: sha512-4NjPB0+bAKjPoponSmTOkK58IEF2W22sOJA5O48k/MxbCZgOm+jrU4WVR53Z2I6xFgIPkVrQmKtt1LAbWtfqXw==}
     engines: {node: '>=16.0.0'}
 
-  hono@4.12.14:
-    resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
+  hono@4.12.7:
+    resolution: {integrity: sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==}
     engines: {node: '>=16.9.0'}
 
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
-
-  hookable@6.1.1:
-    resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
 
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
@@ -2320,10 +2487,6 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
-  http-encoding@2.2.0:
-    resolution: {integrity: sha512-sotL89NNHWS7TjaoswmKkNKf57+nAYCg3fbGCclpNLriVGkOSgrAWQ9DLqahnwacY+gednJk+HFdZrpKw/Ff6w==}
-    engines: {node: '>=v18.0.0'}
-
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
@@ -2331,10 +2494,6 @@ packages:
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
-
-  http2-wrapper@2.2.1:
-    resolution: {integrity: sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==}
-    engines: {node: '>=10.19.0'}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -2347,65 +2506,72 @@ packages:
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
-  impit-darwin-arm64@0.13.1:
-    resolution: {integrity: sha512-ZjIbzorKMe5uwEfryFE5GUNpFXlJPlTslLvO67f8rmt48nWu1JDJdSdnEhvselEgyD6Y1tXwYWFFATMWeOX6zQ==}
+  ignore-by-default@1.0.1:
+    resolution: {integrity: sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==}
+
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  impit-darwin-arm64@0.11.0:
+    resolution: {integrity: sha512-XZcgJQ49hVGoa+bXmXqkvSucyo99X13zggMjqg5lU1SYChpgtsmDG2OyhmKt+if07Y+HtB6EAlCBLl6HPPlbbQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  impit-darwin-x64@0.13.1:
-    resolution: {integrity: sha512-2NY+2nH+qcU4sSGbb4J9MS5CS3lDZYiVRrQXC+1uXAG6cGQuMSsfbf/VVxhMlW8F2bk7vdpKaaUJRQOJT8gyFQ==}
+  impit-darwin-x64@0.11.0:
+    resolution: {integrity: sha512-lyz/HnElBkr/e13pTrBWDocfjVVR6eKrOZmnVeCEPxYlNuPCOslhHp2p+1BdgIQO/8s2X2MVeS0zVSXq3hNp+w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  impit-linux-arm64-gnu@0.13.1:
-    resolution: {integrity: sha512-druR0r2yu9pi26ErMdIE95pnJ+6GO0DKdHfifzr1acE+xKAHYMin4nW65bXLpIVLSLZSBMz+L7lP4vEZ1msC5Q==}
+  impit-linux-arm64-gnu@0.11.0:
+    resolution: {integrity: sha512-xdvbpoPnrAHDtetZjfD6/zqswhg9CRAd7f3YyBFzzNg3aoBRhgMFrdD2BLEWAvaq1PZkj+/emCaPZfJZJfPuJg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  impit-linux-arm64-musl@0.13.1:
-    resolution: {integrity: sha512-k1YA4szvgTvNnNPrqcqPCRzx7OxCal/jrAnUl06VBI3bsGvLklib1maIRp6lDSbge12k7h0DKVQmtyihPt2GDg==}
+  impit-linux-arm64-musl@0.11.0:
+    resolution: {integrity: sha512-w7isVF4RfVynopjGSP+a3/6KJmL7MzdEw2niIi9YjRnCRDPi4XEmxDm9XScB7vUE8E4s7LT8QKa/SIb3MEpvFQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  impit-linux-x64-gnu@0.13.1:
-    resolution: {integrity: sha512-DUy/dZxDd5L9XQVL0pUrILQLtj4eMfExnpdZyQE2qSIe1pmqTndUyJW4UmjRfBkxBHY/sbQGcs0KYRbOWYsIrQ==}
+  impit-linux-x64-gnu@0.11.0:
+    resolution: {integrity: sha512-Y0NBSiFn79G2CXUx2J+a8W2e53ZS7smohsZX18XY8i9LxLf2FQ6pt7e1eWVDHEdo298r5w4EFPc46Gdg6npw+A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  impit-linux-x64-musl@0.13.1:
-    resolution: {integrity: sha512-qoCFYpH1HzPgt5LyPKGxdexwlhuf85/CWYZ35UNjE5TILT8qHW7szHt7CZ2EzDIRS0jkOxL4iZS7AxhFtv7c3g==}
+  impit-linux-x64-musl@0.11.0:
+    resolution: {integrity: sha512-UmahyHiqcNTCYnAgW+SjQwfyqfALYxXeN3Likuf/aS/tzlTP/CPmtNu1O+Vl7G8dZaWRlBNtAwvLeKlkUKBL5A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  impit-win32-arm64-msvc@0.13.1:
-    resolution: {integrity: sha512-w0Y4Rssf9KOAyqtExtFD+He7aG1KPYRw4U0VktZyguDtZHCETbl/ODuddvh3GP4aToRZTpkBuMsDKSogggQbMA==}
+  impit-win32-arm64-msvc@0.11.0:
+    resolution: {integrity: sha512-LppsL30N+EgVx1tsBNsYz2vf8aM+RXpin/9Szzs8G82PD5QmOnrhJE6JTpzyfVYebjn/UdJcIqFzfcZRCciLOg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  impit-win32-x64-msvc@0.13.1:
-    resolution: {integrity: sha512-MAfYan7e+OK0JI70aHc2Qz92O4EaMXAsI1awQcwN0hGIFgbhf8z3q/XIbyy6h67aV1+L8DZYoITxvHoba1CEhg==}
+  impit-win32-x64-msvc@0.11.0:
+    resolution: {integrity: sha512-fXIrgD8EdxDBic90DvcJ350lbeHYTQGybNEQNW7zQrSMEht0A/r7mm9yI1VhhSOiT7glCl96CAvG3mTSGqAipA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
 
-  impit@0.13.1:
-    resolution: {integrity: sha512-nlqkHwotE4OCngPhkgLKPc+CiUSVbpFVfdDr/jWISalB9Mzf9Frw18pJ98rr73G94tEPnkL8Chx9skR11ogguw==}
+  impit@0.11.0:
+    resolution: {integrity: sha512-968YrfzZN5CCgHs/n/yAbPgetq+bOreQOI9UQXmHK3srRs24g+m9CNGL8tRWUIZCK0tnc+baBJ0nw+8saHz0qw==}
     engines: {node: '>= 20'}
 
-  import-without-cache@0.3.3:
-    resolution: {integrity: sha512-bDxwDdF04gm550DfZHgffvlX+9kUlcz32UD0AeBTmVPFiWkrexF2XVmiuFFbDhiFuP8fQkrkvI2KdSNPYWAXkQ==}
-    engines: {node: '>=20.19.0'}
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -2421,27 +2587,37 @@ packages:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
 
-  is-docker@3.0.0:
-    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    hasBin: true
+  is-binary-path@2.1.0:
+    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
+    engines: {node: '>=8'}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
 
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
-  is-in-ssh@1.0.0:
-    resolution: {integrity: sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==}
-    engines: {node: '>=20'}
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
 
-  is-inside-container@1.0.0:
-    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
-    engines: {node: '>=14.16'}
-    hasBin: true
+  is-interactive@2.0.0:
+    resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
+    engines: {node: '>=12'}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
 
   is-obj@2.0.0:
     resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==}
     engines: {node: '>=8'}
+
+  is-plain-object@2.0.4:
+    resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==}
+    engines: {node: '>=0.10.0'}
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
@@ -2452,28 +2628,24 @@ packages:
   is-standalone-pwa@0.1.1:
     resolution: {integrity: sha512-9Cbovsa52vNQCjdXOzeQq5CnCbAcRk05aU62K20WO372NrTv0NxibLFCK6lQ4/iZEFdEA3p3t2VNOn8AJ53F5g==}
 
+  is-unicode-supported@2.1.0:
+    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
+    engines: {node: '>=18'}
+
   is-what@5.5.0:
     resolution: {integrity: sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==}
     engines: {node: '>=18'}
 
-  is-wsl@3.1.1:
-    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
-    engines: {node: '>=16'}
-
-  isarray@1.0.0:
-    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
-
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isobject@3.0.1:
+    resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
+    engines: {node: '>=0.10.0'}
 
   isolated-vm@6.1.2:
     resolution: {integrity: sha512-GGfsHqtlZiiurZaxB/3kY7LLAXR3sgzDul0fom4cSyBjx6ZbjpTrFWiH3z/nUfLJGJ8PIq9LQmQFiAxu24+I7A==}
     engines: {node: '>=22.0.0'}
-
-  isomorphic-ws@4.0.1:
-    resolution: {integrity: sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==}
-    peerDependencies:
-      ws: '*'
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -2487,9 +2659,6 @@ packages:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
 
-  iterall@1.3.0:
-    resolution: {integrity: sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==}
-
   jose@6.2.2:
     resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
 
@@ -2498,6 +2667,16 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jscodeshift@17.3.0:
+    resolution: {integrity: sha512-LjFrGOIORqXBU+jwfC9nbkjmQfFldtMIoS6d9z2LG/lkmyNXsJAySPT+2SWXJEoE68/bCWcxKpXH37npftgmow==}
+    engines: {node: '>=16'}
+    hasBin: true
+    peerDependencies:
+      '@babel/preset-env': ^7.1.6
+    peerDependenciesMeta:
+      '@babel/preset-env':
+        optional: true
 
   jsdom@29.0.2:
     resolution: {integrity: sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==}
@@ -2526,6 +2705,10 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
 
   koffi@2.16.1:
     resolution: {integrity: sha512-0Ie6CfD026dNfWSosDw9dPxPzO9Rlyo0N8m5r05S8YjytIpuilzMFDMY4IDy/8xQsTwpuVinhncD+S8n3bcYZQ==}
@@ -2665,12 +2848,20 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  limiter@3.0.0:
+    resolution: {integrity: sha512-hev7DuXojsTFl2YwyzUJMDnZ/qBDd3yZQLSH3aD4tdL1cqfc3TMnoecEJtWFaQFdErZsKoFMBTxF/FBSkgDbEg==}
+
+  locate-path@3.0.0:
+    resolution: {integrity: sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==}
+    engines: {node: '>=6'}
+
   lodash.isequal@4.5.0:
     resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
     deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
-  lodash@4.18.1:
-    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+  log-symbols@7.0.1:
+    resolution: {integrity: sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==}
+    engines: {node: '>=18'}
 
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
@@ -2691,6 +2882,10 @@ packages:
 
   magicast@0.5.2:
     resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
+
+  make-dir@2.1.0:
+    resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
+    engines: {node: '>=6'}
 
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
@@ -2728,6 +2923,10 @@ packages:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
 
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
   micromark-util-character@2.1.1:
     resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
 
@@ -2743,16 +2942,28 @@ packages:
   micromark-util-types@2.0.2:
     resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
 
-  milliparsec@5.1.1:
-    resolution: {integrity: sha512-jkEDaSWZp4/Q3vprqdqukBqUEyNNqC1pwTjZ5cp9YkaR1wv5fvTCd8VFsecbw7i8DNBGjzhJ83MDoPZlcTaPQg==}
-    engines: {node: '>=18.13 || >=19.20 || >=20'}
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
 
   mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
     engines: {node: '>= 0.6'}
 
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
   mime-types@3.0.2:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+
+  mimic-function@5.0.1:
+    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
 
   mimic-response@3.1.0:
@@ -2783,16 +2994,18 @@ packages:
     resolution: {integrity: sha512-7e87vk0DdWT647wjcfEtWeMtjm+zVGqNohN/aeIymbUfjHQ2T4Sx5kM+1irVDBSloNC3CkGKxswdMoo8yhqTDg==}
     engines: {node: '>=10', npm: '>=6'}
 
-  mockttp@4.3.1:
-    resolution: {integrity: sha512-g9USZI+EPdwdLFqvfETQ0+76+fnIb+3vXPo2qN90rXe+1lCpJJjiGqCJwdhl5bx8wMNEM57DjRSiQVi6oOynWQ==}
-    engines: {node: '>=20.0.0'}
-    hasBin: true
-
-  ms@2.0.0:
-    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
-
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  multimap@1.0.2:
+    resolution: {integrity: sha512-f+Hwg31bbl1pinL1zgqE2/4jiABF0q/qxtK8gpBazeizqYQNt5s7WuZ50y7VtIj50SUxv+2nzrl4K1bO0/hiJw==}
+
+  multimap@1.1.0:
+    resolution: {integrity: sha512-0ZIR9PasPxGXmRsEF8jsDzndzHDj7tIav+JUmvIFB/WHswliFnquxECT/De7GR4yg99ky/NlRKJT82G1y271bw==}
+
+  mylas@2.1.14:
+    resolution: {integrity: sha512-BzQguy9W9NJgoVn2mRWzbFrFWWztGCcng2QI9+41frfk+Athwgx3qhqhvStz7ExeUUu7Kzw427sNzHpEZNINog==}
+    engines: {node: '>=16.0.0'}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -2802,12 +3015,12 @@ packages:
   napi-build-utils@2.0.0:
     resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
 
-  native-duplexpair@1.0.0:
-    resolution: {integrity: sha512-E7QQoM+3jvNtlmyfqRZ0/U75VFgCls+fSkbml2MpgWkWyz3ox8Y58gNhfuziuQYGNNQAbFZJQck55LHCnCK6CA==}
-
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
+
+  neo-async@2.6.2:
+    resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
   netmask@2.1.1:
     resolution: {integrity: sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==}
@@ -2828,6 +3041,15 @@ packages:
   node-releases@2.0.37:
     resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
 
+  nodemon@3.1.14:
+    resolution: {integrity: sha512-jakjZi93UtB3jHMWsXL68FXSAosbLfY0In5gtKq3niLSkrWznrVBzXFNOEMJUfc9+Ke7SHWoAZsiMkNP3vq6Jw==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -2843,16 +3065,16 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
-  on-finished@2.3.0:
-    resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
-    engines: {node: '>= 0.8'}
-
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  onetime@7.0.0:
+    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
+    engines: {node: '>=18'}
 
   oniguruma-to-es@3.1.1:
     resolution: {integrity: sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==}
@@ -2870,16 +3092,28 @@ packages:
   onnxruntime-web@1.26.0-dev.20260416-b7804b056c:
     resolution: {integrity: sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw==}
 
-  open@11.0.0:
-    resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
+  openai@6.34.0:
+    resolution: {integrity: sha512-yEr2jdGf4tVFYG6ohmr3pF6VJuveP0EA/sS8TBx+4Eq5NT10alu5zg2dmxMXMgqpihRDQlFGpRt2XwsGj+Fyxw==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
+  ora@9.4.0:
+    resolution: {integrity: sha512-84cglkRILFxdtA8hAvLNdMrtBpPNBTrQ9/ulg0FA7xLMnD6mifv+enAIeRmvtv+WgdCE+LPGOfQmtJRrVaIVhQ==}
     engines: {node: '>=20'}
 
   ow@0.28.2:
     resolution: {integrity: sha512-dD4UpyBh/9m4X2NVjA+73/ZPBRF+uF4zIMFvvQsabMiEK8x41L3rQ8EENOi35kyyoaJwNxEeJcP6Fj1H4U409Q==}
     engines: {node: '>=12'}
 
-  oxfmt@0.46.0:
-    resolution: {integrity: sha512-CopwJOwPAjZ9p76fCvz+mSOJTw9/NY3cSksZK3VO/bUQ8UoEcketNgUuYS0UB3p+R9XnXe7wGGXUmyFxc7QxJA==}
+  oxfmt@0.44.0:
+    resolution: {integrity: sha512-lnncqvHewyRvaqdrnntVIrZV2tEddz8lbvPsQzG/zlkfvgZkwy0HP1p/2u1aCDToeg1jb9zBpbJdfkV73Itw+w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -2893,6 +3127,18 @@ packages:
       oxlint-tsgolint:
         optional: true
 
+  p-limit@2.3.0:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
+
+  p-locate@3.0.0:
+    resolution: {integrity: sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==}
+    engines: {node: '>=6'}
+
+  p-try@2.2.0:
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
+
   pac-proxy-agent@7.2.0:
     resolution: {integrity: sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==}
     engines: {node: '>= 14'}
@@ -2901,18 +3147,16 @@ packages:
     resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
     engines: {node: '>= 14'}
 
-  parse-multipart-data@1.5.0:
-    resolution: {integrity: sha512-ck5zaMF0ydjGfejNMnlo5YU2oJ+pT+80Jb1y4ybanT27j+zbVP/jkYmCrUGsEln0Ox/hZmuvgy8Ra7AxbXP2Mw==}
-
-  parse5@7.3.0:
-    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
-
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
+
+  path-exists@3.0.0:
+    resolution: {integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==}
+    engines: {node: '>=4'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -2924,6 +3168,10 @@ packages:
 
   path-to-regexp@8.4.0:
     resolution: {integrity: sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==}
+
+  path-type@4.0.0:
+    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
+    engines: {node: '>=8'}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -2937,17 +3185,29 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
+
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
-  pify@5.0.0:
-    resolution: {integrity: sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==}
-    engines: {node: '>=10'}
+  pify@4.0.1:
+    resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
+    engines: {node: '>=6'}
+
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
 
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
+
+  pkg-dir@3.0.0:
+    resolution: {integrity: sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==}
+    engines: {node: '>=6'}
 
   platform@1.3.6:
     resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
@@ -2957,13 +3217,13 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  plimit-lit@1.6.1:
+    resolution: {integrity: sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==}
+    engines: {node: '>=12'}
+
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
-
-  powershell-utils@0.1.0:
-    resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
-    engines: {node: '>=20'}
 
   preact@10.29.1:
     resolution: {integrity: sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==}
@@ -2978,9 +3238,6 @@ packages:
     resolution: {integrity: sha512-nODzvTiYVRGRqAOvE84Vk5JDPyyxsVk0/fbA/bq7RqlnhksGpset09XTxbpvLTIjoaF7K8Z8DG8yHtKGTPSYRw==}
     engines: {node: '>=20'}
 
-  process-nextick-args@2.0.1:
-    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
-
   progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
@@ -2988,8 +3245,8 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
-  protobufjs@8.0.1:
-    resolution: {integrity: sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==}
+  protobufjs@7.5.5:
+    resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
     engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
@@ -3003,6 +3260,13 @@ packages:
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
+
+  pstree.remy@1.1.8:
+    resolution: {integrity: sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==}
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
@@ -3010,23 +3274,16 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  pvtsutils@1.3.6:
-    resolution: {integrity: sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==}
-
-  pvutils@1.1.5:
-    resolution: {integrity: sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==}
-    engines: {node: '>=16.0.0'}
-
   qs@6.15.1:
     resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
     engines: {node: '>=0.6'}
 
-  quansync@1.0.0:
-    resolution: {integrity: sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==}
+  queue-lit@1.5.2:
+    resolution: {integrity: sha512-tLc36IOPeMAubu8BkW8YDBV+WyIgKlYU7zUNs0J5Vk9skSZ4JfGlPOqplP0aHdfv7HL0B2Pg6nwiq60Qc6M2Hw==}
+    engines: {node: '>=12'}
 
-  quick-lru@5.1.1:
-    resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
-    engines: {node: '>=10'}
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
   quickjs-emscripten-core@0.32.0:
     resolution: {integrity: sha512-QFnPfjFey8EqknSrSxe1hZrf1/8z7/6s1QzGOmKo6++02r7QRRX7ZoyNaZh7JuVjWsVW87KnQrbZqnHkOAzUyg==}
@@ -3047,23 +3304,21 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
-  read-tls-client-hello@2.0.0:
-    resolution: {integrity: sha512-zPrnTO77iw1KUjg5QlDzxSRg69SCeWqMI5dY2tEZJc2mDL7RmmpG+RF2Qw9p4JlZ2PUAuJWLFB+ti8o9mTiO6A==}
-    engines: {node: '>=20.0.0'}
-
-  readable-stream@2.3.8:
-    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
-
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
+
+  readdirp@3.6.0:
+    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
+    engines: {node: '>=8.10.0'}
 
   rebrowser-puppeteer-core@24.8.1:
     resolution: {integrity: sha512-CifPf47KTG0jajTyn/dWpvf3kpW5W1QesURCWaUGzNTN8Kkki2IBUKJaMS+R+eNKhfv1JcsCZ5glYI0RAyJPTg==}
     engines: {node: '>=18'}
 
-  reflect-metadata@0.2.2:
-    resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
+  recast@0.23.11:
+    resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
+    engines: {node: '>= 4'}
 
   regex-recursion@6.0.2:
     resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
@@ -3082,11 +3337,16 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
-  resolve-alpn@1.2.1:
-    resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
-
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  restore-cursor@5.1.0:
+    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
+    engines: {node: '>=18'}
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
@@ -3095,53 +3355,22 @@ packages:
     resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
     engines: {node: '>=8.0'}
 
-  rolldown-plugin-dts@0.23.2:
-    resolution: {integrity: sha512-PbSqLawLgZBGcOGT3yqWBGn4cX+wh2nt5FuBGdcMHyOhoukmjbhYAl8NT9sE4U38Cm9tqLOIQeOrvzeayM0DLQ==}
-    engines: {node: '>=20.19.0'}
-    peerDependencies:
-      '@ts-macro/tsc': ^0.3.6
-      '@typescript/native-preview': '>=7.0.0-dev.20260325.1'
-      rolldown: ^1.0.0-rc.12
-      typescript: ^5.0.0 || ^6.0.0
-      vue-tsc: ~3.2.0
-    peerDependenciesMeta:
-      '@ts-macro/tsc':
-        optional: true
-      '@typescript/native-preview':
-        optional: true
-      typescript:
-        optional: true
-      vue-tsc:
-        optional: true
-
   rolldown@1.0.0-rc.17:
     resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  rollup-plugin-visualizer@7.0.1:
-    resolution: {integrity: sha512-UJUT4+1Ho4OcWmPYU3sYXgUqI8B8Ayfe06MX7y0qCJ1K8aGoKtR/NDd/2nZqM7ADkrzny+I99Ul7GgyoiVNAgg==}
-    engines: {node: '>=22'}
+  rollup@4.60.2:
+    resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
-    peerDependencies:
-      rolldown: 1.x || ^1.0.0-beta || ^1.0.0-rc
-      rollup: 2.x || 3.x || 4.x
-    peerDependenciesMeta:
-      rolldown:
-        optional: true
-      rollup:
-        optional: true
 
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
 
-  run-applescript@7.1.0:
-    resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
-    engines: {node: '>=18'}
-
-  safe-buffer@5.1.2:
-    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
@@ -3162,6 +3391,10 @@ packages:
 
   semver-compare@1.0.0:
     resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
+
+  semver@5.7.2:
+    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
+    hasBin: true
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -3187,6 +3420,10 @@ packages:
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
+  shallow-clone@3.0.1:
+    resolution: {integrity: sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==}
+    engines: {node: '>=8'}
+
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -3198,6 +3435,63 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shift-ast@5.0.0:
+    resolution: {integrity: sha512-kMhr/GwgrQ1U2kaa50sD5YxNDQEZHAZigVwrf/NNeezb6oiYnpPMV8v1WVRhCW8sjI7xUdzuPujSQ3gA2IuUAQ==}
+
+  shift-ast@6.0.0:
+    resolution: {integrity: sha512-XXxDcEBWVBzqWXfNYJlLyJ1/9kMvOXVRXiqPjkOrTCC5qRsBvEMJMRLLFhU3tn8ue56Y7IZyBE6bexFum5QLUw==}
+
+  shift-ast@6.1.0:
+    resolution: {integrity: sha512-Vj4XUIJIFPIh6VcBGJ1hjH/kM88XGer94Pr7Rvxa+idEylDsrwtLw268HoxGo5xReL6T3DdRl/9/Pr1XihZ/8Q==}
+
+  shift-ast@7.0.0:
+    resolution: {integrity: sha512-O0INwsZa1XH/lMSf52udGnjNOxKBLxFiZHt0Ys3i6bqtwuGEA3eDR4+e0qJELIsCy8+BiTtlTgQzP76K1ehipQ==}
+
+  shift-parser@7.0.3:
+    resolution: {integrity: sha512-uYX2ORyZfKZrUc4iKKkO9KOhzUSxCrSBk7QK6ZmShId+BOo1gh1IwecVy97ynyOTpmhPWUttjC8BzsnQl65Zew==}
+
+  shift-parser@8.0.0:
+    resolution: {integrity: sha512-IShW1wGhvA5e+SPNVQ+Dwi/Be6651F2jZc6wwYHbYW7PiswAYfvR/v3Q+CjjxsVCna5L6J5OtR6y+tkkCzvCfw==}
+
+  shift-printer@1.0.1:
+    resolution: {integrity: sha512-kv59gA/8dZuz175dqbnBEJQH9ctusX3IDaA50oWcSGq5LOxLxZ4Rl6+7rMsiQywxA7K4FBJY/XJ+OEz0f5Ux0w==}
+
+  shift-query@1.0.2:
+    resolution: {integrity: sha512-tgYZE58U/wl3wiAsDVB7UnuMZVL8TAlLoYu0lBGvs/Kj2cywJKl54BrwUerdkA1cMieiyNx1SbBG5+mOntTIBQ==}
+
+  shift-reducer@5.0.0:
+    resolution: {integrity: sha512-Jgr6kPMZuzsQ63NdeLJT6BZvtJ6IDbYFBVqiid1bZlwxeJYq81Cj2Wc4UUERjO4Q9tz5U4KpWaZhitjcBvfiYA==}
+
+  shift-reducer@6.0.0:
+    resolution: {integrity: sha512-2rJraRP8drIOjvaE/sALa+0tGJmMVUzlmS3wIJerJbaYuCjpFAiF0WjkTOFVtz1144Nm/ECmqeG+7yRhuMVsMg==}
+
+  shift-reducer@7.0.0:
+    resolution: {integrity: sha512-9igIDMHzp1+CkQZITGHM1sAd9jqMPV0vhqHuh8jlYumHSMIwsYcrDeo1tlpzNRUnfbEq1nLyh8Bf1YU8HGUE7g==}
+
+  shift-refactor@2.0.0:
+    resolution: {integrity: sha512-9pO3WQ3oHb9FXVxGhVSMUajCtiwUhfqAWv1H1bkinwFdoR2l4IzVDdQYThMNg5UUEZhg52XBMB15WUxX4vzQKg==}
+
+  shift-regexp-acceptor@2.0.3:
+    resolution: {integrity: sha512-sxL7e5JNUFxm+gutFRXktX2D6KVgDAHNuDsk5XHB9Z+N5yXooZG6pdZ1GEbo3Jz6lF7ETYLBC4WAjIFm2RKTmA==}
+
+  shift-regexp-acceptor@3.0.0:
+    resolution: {integrity: sha512-98UKizBjHY6SjjLUr51YYw4rtR+vxjGFm8znqNsoahesAI8Y9+WVAyiBCxxkov1KSDhW0Wz8FwwUqHnlFnjdUg==}
+
+  shift-scope@4.0.0:
+    resolution: {integrity: sha512-b5Ub5m6eP3obI1h6MVmt3Rthh1akLKKjresLtYYqV+V4aNFL1XtdvB+yK6mTROakriKFu4ehwbs6mFMUCenyKA==}
+
+  shift-spec@2017.0.0:
+    resolution: {integrity: sha512-bJvpDhV0BPI3Qtr0Dztrv9nKjQmeSlRRjMOPe5ojsnzauhwu3fls+iMT6qDUXS+kXloZo71dn15j9D2qWuuQvw==}
+
+  shift-spec@2018.0.0:
+    resolution: {integrity: sha512-/aiPOkj7dbe+CV2VZhIMTHQToZmgniofpRG7Yr7x2/0sO6CSVC++py1Wzf+s+rWSTDHKcLvziVAxjRRV4i4EoQ==}
+
+  shift-traverser@1.0.0:
+    resolution: {integrity: sha512-DMY3512wJbdC+IC+nhLH3/Stgr2BbxbNcg7qyZ6+e5qNnNs8TBQJWdMsRgHlX1JXwF4C0ONKS8VUxsPT0Tf7aw==}
+
+  shift-validator@5.0.1:
+    resolution: {integrity: sha512-q0uUu2IWgEnItpuTbL1HGJkfBWKTGhDMTOqe1ANlc6qfV6jo1E3LB2P1rAVWQnOl+9iZSfdqYzNIACZ0j07l4Q==}
 
   shiki@2.5.0:
     resolution: {integrity: sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ==}
@@ -3221,11 +3515,23 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
   simple-concat@1.0.1:
     resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
 
   simple-get@4.0.1:
     resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
+  simple-update-notifier@2.0.0:
+    resolution: {integrity: sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==}
+    engines: {node: '>=10'}
+
+  slash@3.0.0:
+    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
+    engines: {node: '>=8'}
 
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
@@ -3243,13 +3549,12 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  source-map-support@0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
-
-  source-map@0.7.6:
-    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
-    engines: {node: '>= 12'}
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
@@ -3267,10 +3572,6 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
-  statuses@1.5.0:
-    resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
-    engines: {node: '>= 0.6'}
-
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
@@ -3278,8 +3579,9 @@ packages:
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
-  stream-shift@1.0.3:
-    resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
+  stdin-discarder@0.3.2:
+    resolution: {integrity: sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==}
+    engines: {node: '>=18'}
 
   streamx@2.25.0:
     resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
@@ -3288,12 +3590,9 @@ packages:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
 
-  string-width@7.2.0:
-    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
-    engines: {node: '>=18'}
-
-  string_decoder@1.1.1:
-    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
+  string-width@8.2.0:
+    resolution: {integrity: sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==}
+    engines: {node: '>=20'}
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -3317,13 +3616,13 @@ packages:
     resolution: {integrity: sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==}
     engines: {node: '>=16'}
 
+  supports-color@5.5.0:
+    resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
+    engines: {node: '>=4'}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
-
-  symbol-observable@1.2.0:
-    resolution: {integrity: sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==}
-    engines: {node: '>=0.10.0'}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -3352,6 +3651,9 @@ packages:
 
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
+
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
   tiny-lru@13.0.0:
     resolution: {integrity: sha512-xDHxKKS1FdF0Tv2P+QT7IeSEg74K/8cEDzbv3Tv6UyHHUgBOjOiQiBp818MGj66dhurQus/IBcoAbwIKtSGc6Q==}
@@ -3383,9 +3685,21 @@ packages:
     resolution: {integrity: sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==}
     hasBin: true
 
+  tmp@0.2.5:
+    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+    engines: {node: '>=14.14'}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  touch@3.1.1:
+    resolution: {integrity: sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==}
+    hasBin: true
 
   tough-cookie@6.0.1:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
@@ -3395,55 +3709,21 @@ packages:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
 
-  tree-kill@1.2.2:
-    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
-    hasBin: true
-
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
-  tsdown@0.21.10:
-    resolution: {integrity: sha512-3wk73yBhZe/wX7REqSdivNQ84TDs1mJ+IlnzrrEREP70xlJ/AEIzqaI04l/TzMKVIdkTdC3CPaADn2Lk/0SkdA==}
-    engines: {node: '>=20.19.0'}
+  tsc-alias@1.8.16:
+    resolution: {integrity: sha512-QjCyu55NFyRSBAl6+MTFwplpFcnm2Pq01rR/uxfqJoLMm6X3O14KEGtaSDZpJYaE1bJBGDjD0eSuiIWPe2T58g==}
+    engines: {node: '>=16.20.2'}
     hasBin: true
-    peerDependencies:
-      '@arethetypeswrong/core': ^0.18.1
-      '@tsdown/css': 0.21.10
-      '@tsdown/exe': 0.21.10
-      '@vitejs/devtools': '*'
-      publint: ^0.3.0
-      typescript: ^5.0.0 || ^6.0.0
-      unplugin-unused: ^0.5.0
-    peerDependenciesMeta:
-      '@arethetypeswrong/core':
-        optional: true
-      '@tsdown/css':
-        optional: true
-      '@tsdown/exe':
-        optional: true
-      '@vitejs/devtools':
-        optional: true
-      publint:
-        optional: true
-      typescript:
-        optional: true
-      unplugin-unused:
-        optional: true
-
-  tslib@1.14.1:
-    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  tsx@4.21.0:
-    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+  tsx@4.16.1:
+    resolution: {integrity: sha512-UAKkKOFMJI4M3U4xTJuoqECBMydJbqwNuACoMvwHjqDhbQyo/SYd8ZYNCpF5F8rAjcdKrO+z9CbvBlBiFKhBLA==}
     engines: {node: '>=18.0.0'}
     hasBin: true
-
-  tsyringe@4.10.0:
-    resolution: {integrity: sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==}
-    engines: {node: '>= 6.0.0'}
 
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
@@ -3471,18 +3751,31 @@ packages:
     resolution: {integrity: sha512-OsqGhxyo/wGdLSXMSJxuMGN6H4gDnKz6Fb3IBm4bxZFMnyy0sdf6MN96Ie8tC6z/btdO+Bsy8guxlvLdwT076w==}
     hasBin: true
 
-  unconfig-core@7.5.0:
-    resolution: {integrity: sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==}
+  undefsafe@2.0.5:
+    resolution: {integrity: sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==}
 
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
-  undici-types@7.25.0:
-    resolution: {integrity: sha512-AXNgS1Byr27fTI+2bsPEkV9CxkT8H6xNyRI68b3TatlZo3RkzlqQBLL+w7SmGPVpokjHbcuNVQUWE7FRTg+LRA==}
-
   undici@7.25.0:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
+
+  unicode-canonical-property-names-ecmascript@1.0.4:
+    resolution: {integrity: sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==}
+    engines: {node: '>=4'}
+
+  unicode-match-property-ecmascript@1.0.4:
+    resolution: {integrity: sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==}
+    engines: {node: '>=4'}
+
+  unicode-match-property-value-ecmascript@1.0.2:
+    resolution: {integrity: sha512-Rx7yODZC1L/T8XKo/2kNzVAQaRE88AaMvI1EF/Xnj3GW2wzN6fop9DDWuFAKUVFH7vozkz26DzP0qyWLKLIVPQ==}
+    engines: {node: '>=4'}
+
+  unicode-property-aliases-ecmascript@1.0.4:
+    resolution: {integrity: sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg==}
+    engines: {node: '>=4'}
 
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
@@ -3503,31 +3796,14 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
-  unrun@0.2.37:
-    resolution: {integrity: sha512-AA7vDuYsgeSYVzJMm16UKA+aXFKhy7nFqW9z5l7q44K4ppFWZAMqYS58ePRZbugMLPH0fwwMzD5A8nP0avxwZQ==}
-    engines: {node: '>=20.19.0'}
-    hasBin: true
-    peerDependencies:
-      synckit: ^0.11.11
-    peerDependenciesMeta:
-      synckit:
-        optional: true
-
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
 
-  urlpattern-polyfill@10.1.0:
-    resolution: {integrity: sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==}
-
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
-
-  utils-merge@1.0.1:
-    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
-    engines: {node: '>= 0.4.0'}
 
   vali-date@1.0.0:
     resolution: {integrity: sha512-sgECfZthyaCKW10N0fm27cg8HYTFK5qMWgypqkXMQ4Wbl/zZKx7xZICgcoxIIE+WFAP/MBL2EFwC/YvLxw3Zeg==}
@@ -3542,6 +3818,37 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
 
   vite@8.0.10:
     resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
@@ -3681,12 +3988,12 @@ packages:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
 
-  wrap-ansi@9.0.2:
-    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
-    engines: {node: '>=18'}
-
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  write-file-atomic@5.0.1:
+    resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   ws@8.20.0:
     resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
@@ -3699,10 +4006,6 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
-
-  wsl-utils@0.3.1:
-    resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
-    engines: {node: '>=20'}
 
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
@@ -3719,10 +4022,6 @@ packages:
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
-  xtend@4.0.2:
-    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
-    engines: {node: '>=0.4'}
-
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -3734,20 +4033,16 @@ packages:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
 
-  yargs-parser@22.0.0:
-    resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
-
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
 
-  yargs@18.0.0:
-    resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
-
   yauzl@2.10.0:
     resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
+
+  yoctocolors@2.1.2:
+    resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
+    engines: {node: '>=18'}
 
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
@@ -3759,9 +4054,6 @@ packages:
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
-
-  zstd-codec@0.1.5:
-    resolution: {integrity: sha512-v3fyjpK8S/dpY/X5WxqTK3IoCnp/ZOLxn144GZVlNUjtwAchzrVo03h+oMATFhCIiJ5KTr4V3vDQQYz4RU684g==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -3887,6 +4179,7 @@ snapshots:
       '@csstools/css-color-parser': 4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
+    optional: true
 
   '@asamuzakjp/dom-selector@7.1.1':
     dependencies:
@@ -3895,10 +4188,13 @@ snapshots:
       bidi-js: 1.0.3
       css-tree: 3.2.1
       is-potential-custom-element-name: 1.0.1
+    optional: true
 
-  '@asamuzakjp/generational-cache@1.0.1': {}
+  '@asamuzakjp/generational-cache@1.0.1':
+    optional: true
 
-  '@asamuzakjp/nwsapi@2.3.9': {}
+  '@asamuzakjp/nwsapi@2.3.9':
+    optional: true
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -3906,8 +4202,7 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/compat-data@7.29.0':
-    optional: true
+  '@babel/compat-data@7.29.0': {}
 
   '@babel/core@7.29.0':
     dependencies:
@@ -3922,13 +4217,12 @@ snapshots:
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   '@babel/generator@7.29.1':
     dependencies:
@@ -3938,14 +4232,9 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
-  '@babel/generator@8.0.0-rc.3':
+  '@babel/helper-annotate-as-pure@7.27.3':
     dependencies:
-      '@babel/parser': 8.0.0-rc.3
-      '@babel/types': 8.0.0-rc.3
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
-      '@types/jsesc': 2.5.1
-      jsesc: 3.1.0
+      '@babel/types': 7.29.0
 
   '@babel/helper-compilation-targets@7.28.6':
     dependencies:
@@ -3954,9 +4243,28 @@ snapshots:
       browserslist: 4.28.2
       lru-cache: 5.1.1
       semver: 6.3.1
-    optional: true
+
+  '@babel/helper-create-class-features-plugin@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-member-expression-to-functions': 7.28.5
+      '@babel/helper-optimise-call-expression': 7.27.1
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/traverse': 7.29.0
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-member-expression-to-functions@7.28.5':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/helper-module-imports@7.28.6':
     dependencies:
@@ -3964,7 +4272,6 @@ snapshots:
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -3974,32 +4281,139 @@ snapshots:
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
-    optional: true
+
+  '@babel/helper-optimise-call-expression@7.27.1':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/helper-plugin-utils@7.28.6': {}
+
+  '@babel/helper-replace-supers@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-member-expression-to-functions': 7.28.5
+      '@babel/helper-optimise-call-expression': 7.27.1
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/helper-string-parser@7.27.1': {}
 
-  '@babel/helper-string-parser@8.0.0-rc.3': {}
-
   '@babel/helper-validator-identifier@7.28.5': {}
 
-  '@babel/helper-validator-identifier@8.0.0-rc.3': {}
-
-  '@babel/helper-validator-option@7.27.1':
-    optional: true
+  '@babel/helper-validator-option@7.27.1': {}
 
   '@babel/helpers@7.29.2':
     dependencies:
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-    optional: true
 
   '@babel/parser@7.29.2':
     dependencies:
       '@babel/types': 7.29.0
 
-  '@babel/parser@8.0.0-rc.3':
+  '@babel/plugin-syntax-flow@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/types': 8.0.0-rc.3
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-class-properties@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-flow-strip-types@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/plugin-syntax-flow': 7.28.6(@babel/core@7.29.0)
+
+  '@babel/plugin-transform-modules-commonjs@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-nullish-coalescing-operator@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-optional-chaining@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-private-methods@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-typescript@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/preset-flow@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-validator-option': 7.27.1
+      '@babel/plugin-transform-flow-strip-types': 7.27.1(@babel/core@7.29.0)
+
+  '@babel/preset-typescript@7.28.5(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-validator-option': 7.27.1
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/register@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      clone-deep: 4.0.1
+      find-cache-dir: 2.1.0
+      make-dir: 2.1.0
+      pirates: 4.0.7
+      source-map-support: 0.5.21
 
   '@babel/template@7.28.6':
     dependencies:
@@ -4015,7 +4429,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -4024,16 +4438,12 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@babel/types@8.0.0-rc.3':
-    dependencies:
-      '@babel/helper-string-parser': 8.0.0-rc.3
-      '@babel/helper-validator-identifier': 8.0.0-rc.3
-
   '@bcoe/v8-coverage@1.0.2': {}
 
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
+    optional: true
 
   '@codemod/matchers@1.7.1':
     dependencies:
@@ -4057,12 +4467,14 @@ snapshots:
       - supports-color
     optional: true
 
-  '@csstools/color-helpers@6.0.2': {}
+  '@csstools/color-helpers@6.0.2':
+    optional: true
 
   '@csstools/css-calc@3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
+    optional: true
 
   '@csstools/css-color-parser@4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
@@ -4070,16 +4482,20 @@ snapshots:
       '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
+    optional: true
 
   '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
     dependencies:
       '@csstools/css-tokenizer': 4.0.0
+    optional: true
 
   '@csstools/css-syntax-patches-for-csstree@1.1.3(css-tree@3.2.1)':
     optionalDependencies:
       css-tree: 3.2.1
+    optional: true
 
-  '@csstools/css-tokenizer@4.0.0': {}
+  '@csstools/css-tokenizer@4.0.0':
+    optional: true
 
   '@devicefarmer/adbkit-logcat@2.1.3':
     optional: true
@@ -4220,74 +4636,16 @@ snapshots:
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
-  '@exodus/bytes@1.15.0': {}
-
-  '@graphql-tools/merge@9.1.8(graphql@15.10.2)':
-    dependencies:
-      '@graphql-tools/utils': 11.0.1(graphql@15.10.2)
-      graphql: 15.10.2
-      tslib: 2.8.1
-
-  '@graphql-tools/schema@10.0.32(graphql@15.10.2)':
-    dependencies:
-      '@graphql-tools/merge': 9.1.8(graphql@15.10.2)
-      '@graphql-tools/utils': 11.0.1(graphql@15.10.2)
-      graphql: 15.10.2
-      tslib: 2.8.1
-
-  '@graphql-tools/utils@11.0.1(graphql@15.10.2)':
-    dependencies:
-      '@graphql-typed-document-node/core': 3.2.0(graphql@15.10.2)
-      '@whatwg-node/promise-helpers': 1.3.2
-      cross-inspect: 1.0.1
-      graphql: 15.10.2
-      tslib: 2.8.1
-
-  '@graphql-typed-document-node/core@3.2.0(graphql@15.10.2)':
-    dependencies:
-      graphql: 15.10.2
-
-  '@hono/node-server@1.19.13(hono@4.12.14)':
-    dependencies:
-      hono: 4.12.14
-
-  '@httptoolkit/httpolyglot@3.0.1':
-    dependencies:
-      '@types/node': 25.6.0
-
-  '@httptoolkit/subscriptions-transport-ws@0.11.2(graphql@15.10.2)':
-    dependencies:
-      backo2: 1.0.2
-      eventemitter3: 3.1.2
-      graphql: 15.10.2
-      iterall: 1.3.0
-      symbol-observable: 1.2.0
-      ws: 8.20.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
-  '@httptoolkit/util@0.1.9': {}
-
-  '@httptoolkit/websocket-stream@6.0.1':
-    dependencies:
-      '@types/ws': 8.18.1
-      duplexify: 3.7.1
-      inherits: 2.0.4
-      isomorphic-ws: 4.0.1(ws@8.20.0)
-      readable-stream: 2.3.8
-      safe-buffer: 5.2.1
-      ws: 8.20.0
-      xtend: 4.0.2
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
-  '@huggingface/jinja@0.5.7':
+  '@exodus/bytes@1.15.0':
     optional: true
 
-  '@huggingface/tokenizers@0.1.3':
-    optional: true
+  '@hono/node-server@1.19.11(hono@4.12.7)':
+    dependencies:
+      hono: 4.12.7
+
+  '@huggingface/jinja@0.5.7': {}
+
+  '@huggingface/tokenizers@0.1.3': {}
 
   '@huggingface/transformers@4.2.0':
     dependencies:
@@ -4296,7 +4654,6 @@ snapshots:
       onnxruntime-node: 1.24.3
       onnxruntime-web: 1.26.0-dev.20260416-b7804b056c
       sharp: 0.34.5
-    optional: true
 
   '@iconify-json/simple-icons@1.2.77':
     dependencies:
@@ -4304,8 +4661,7 @@ snapshots:
 
   '@iconify/types@2.0.0': {}
 
-  '@img/colour@1.1.0':
-    optional: true
+  '@img/colour@1.1.0': {}
 
   '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
@@ -4428,7 +4784,6 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
-    optional: true
 
   '@jridgewell/resolve-uri@3.1.2': {}
 
@@ -4439,9 +4794,15 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@jsoverson/shift-codegen@7.0.0':
+    dependencies:
+      esutils: 2.0.3
+      object-assign: 4.1.1
+      shift-reducer: 6.0.0
+
   '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 1.19.13(hono@4.12.14)
+      '@hono/node-server': 1.19.11(hono@4.12.7)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -4451,7 +4812,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.0(express@5.2.1)
-      hono: 4.12.14
+      hono: 4.12.7
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -4468,63 +4829,75 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.20.1
+
   '@oxc-project/types@0.127.0': {}
 
-  '@oxfmt/binding-android-arm-eabi@0.46.0':
+  '@oxfmt/binding-android-arm-eabi@0.44.0':
     optional: true
 
-  '@oxfmt/binding-android-arm64@0.46.0':
+  '@oxfmt/binding-android-arm64@0.44.0':
     optional: true
 
-  '@oxfmt/binding-darwin-arm64@0.46.0':
+  '@oxfmt/binding-darwin-arm64@0.44.0':
     optional: true
 
-  '@oxfmt/binding-darwin-x64@0.46.0':
+  '@oxfmt/binding-darwin-x64@0.44.0':
     optional: true
 
-  '@oxfmt/binding-freebsd-x64@0.46.0':
+  '@oxfmt/binding-freebsd-x64@0.44.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm-gnueabihf@0.46.0':
+  '@oxfmt/binding-linux-arm-gnueabihf@0.44.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm-musleabihf@0.46.0':
+  '@oxfmt/binding-linux-arm-musleabihf@0.44.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm64-gnu@0.46.0':
+  '@oxfmt/binding-linux-arm64-gnu@0.44.0':
     optional: true
 
-  '@oxfmt/binding-linux-arm64-musl@0.46.0':
+  '@oxfmt/binding-linux-arm64-musl@0.44.0':
     optional: true
 
-  '@oxfmt/binding-linux-ppc64-gnu@0.46.0':
+  '@oxfmt/binding-linux-ppc64-gnu@0.44.0':
     optional: true
 
-  '@oxfmt/binding-linux-riscv64-gnu@0.46.0':
+  '@oxfmt/binding-linux-riscv64-gnu@0.44.0':
     optional: true
 
-  '@oxfmt/binding-linux-riscv64-musl@0.46.0':
+  '@oxfmt/binding-linux-riscv64-musl@0.44.0':
     optional: true
 
-  '@oxfmt/binding-linux-s390x-gnu@0.46.0':
+  '@oxfmt/binding-linux-s390x-gnu@0.44.0':
     optional: true
 
-  '@oxfmt/binding-linux-x64-gnu@0.46.0':
+  '@oxfmt/binding-linux-x64-gnu@0.44.0':
     optional: true
 
-  '@oxfmt/binding-linux-x64-musl@0.46.0':
+  '@oxfmt/binding-linux-x64-musl@0.44.0':
     optional: true
 
-  '@oxfmt/binding-openharmony-arm64@0.46.0':
+  '@oxfmt/binding-openharmony-arm64@0.44.0':
     optional: true
 
-  '@oxfmt/binding-win32-arm64-msvc@0.46.0':
+  '@oxfmt/binding-win32-arm64-msvc@0.44.0':
     optional: true
 
-  '@oxfmt/binding-win32-ia32-msvc@0.46.0':
+  '@oxfmt/binding-win32-ia32-msvc@0.44.0':
     optional: true
 
-  '@oxfmt/binding-win32-x64-msvc@0.46.0':
+  '@oxfmt/binding-win32-x64-msvc@0.44.0':
     optional: true
 
   '@oxlint/binding-android-arm-eabi@1.61.0':
@@ -4584,132 +4957,32 @@ snapshots:
   '@oxlint/binding-win32-x64-msvc@1.61.0':
     optional: true
 
-  '@peculiar/asn1-cms@2.6.1':
-    dependencies:
-      '@peculiar/asn1-schema': 2.6.0
-      '@peculiar/asn1-x509': 2.6.1
-      '@peculiar/asn1-x509-attr': 2.6.1
-      asn1js: 3.0.7
-      tslib: 2.8.1
+  '@protobufjs/aspromise@1.1.2': {}
 
-  '@peculiar/asn1-csr@2.6.1':
-    dependencies:
-      '@peculiar/asn1-schema': 2.6.0
-      '@peculiar/asn1-x509': 2.6.1
-      asn1js: 3.0.7
-      tslib: 2.8.1
+  '@protobufjs/base64@1.1.2': {}
 
-  '@peculiar/asn1-ecc@2.6.1':
-    dependencies:
-      '@peculiar/asn1-schema': 2.6.0
-      '@peculiar/asn1-x509': 2.6.1
-      asn1js: 3.0.7
-      tslib: 2.8.1
+  '@protobufjs/codegen@2.0.4': {}
 
-  '@peculiar/asn1-pfx@2.6.1':
-    dependencies:
-      '@peculiar/asn1-cms': 2.6.1
-      '@peculiar/asn1-pkcs8': 2.6.1
-      '@peculiar/asn1-rsa': 2.6.1
-      '@peculiar/asn1-schema': 2.6.0
-      asn1js: 3.0.7
-      tslib: 2.8.1
-
-  '@peculiar/asn1-pkcs8@2.6.1':
-    dependencies:
-      '@peculiar/asn1-schema': 2.6.0
-      '@peculiar/asn1-x509': 2.6.1
-      asn1js: 3.0.7
-      tslib: 2.8.1
-
-  '@peculiar/asn1-pkcs9@2.6.1':
-    dependencies:
-      '@peculiar/asn1-cms': 2.6.1
-      '@peculiar/asn1-pfx': 2.6.1
-      '@peculiar/asn1-pkcs8': 2.6.1
-      '@peculiar/asn1-schema': 2.6.0
-      '@peculiar/asn1-x509': 2.6.1
-      '@peculiar/asn1-x509-attr': 2.6.1
-      asn1js: 3.0.7
-      tslib: 2.8.1
-
-  '@peculiar/asn1-rsa@2.6.1':
-    dependencies:
-      '@peculiar/asn1-schema': 2.6.0
-      '@peculiar/asn1-x509': 2.6.1
-      asn1js: 3.0.7
-      tslib: 2.8.1
-
-  '@peculiar/asn1-schema@2.6.0':
-    dependencies:
-      asn1js: 3.0.7
-      pvtsutils: 1.3.6
-      tslib: 2.8.1
-
-  '@peculiar/asn1-x509-attr@2.6.1':
-    dependencies:
-      '@peculiar/asn1-schema': 2.6.0
-      '@peculiar/asn1-x509': 2.6.1
-      asn1js: 3.0.7
-      tslib: 2.8.1
-
-  '@peculiar/asn1-x509@2.6.1':
-    dependencies:
-      '@peculiar/asn1-schema': 2.6.0
-      asn1js: 3.0.7
-      pvtsutils: 1.3.6
-      tslib: 2.8.1
-
-  '@peculiar/x509@1.14.3':
-    dependencies:
-      '@peculiar/asn1-cms': 2.6.1
-      '@peculiar/asn1-csr': 2.6.1
-      '@peculiar/asn1-ecc': 2.6.1
-      '@peculiar/asn1-pkcs9': 2.6.1
-      '@peculiar/asn1-rsa': 2.6.1
-      '@peculiar/asn1-schema': 2.6.0
-      '@peculiar/asn1-x509': 2.6.1
-      pvtsutils: 1.3.6
-      reflect-metadata: 0.2.2
-      tslib: 2.8.1
-      tsyringe: 4.10.0
-
-  '@protobufjs/aspromise@1.1.2':
-    optional: true
-
-  '@protobufjs/base64@1.1.2':
-    optional: true
-
-  '@protobufjs/codegen@2.0.4':
-    optional: true
-
-  '@protobufjs/eventemitter@1.1.0':
-    optional: true
+  '@protobufjs/eventemitter@1.1.0': {}
 
   '@protobufjs/fetch@1.1.0':
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/inquire': 1.1.0
-    optional: true
 
-  '@protobufjs/float@1.0.2':
-    optional: true
+  '@protobufjs/float@1.0.2': {}
 
-  '@protobufjs/inquire@1.1.0':
-    optional: true
+  '@protobufjs/inquire@1.1.0': {}
 
-  '@protobufjs/path@1.1.2':
-    optional: true
+  '@protobufjs/path@1.1.2': {}
 
-  '@protobufjs/pool@1.1.0':
-    optional: true
+  '@protobufjs/pool@1.1.0': {}
 
-  '@protobufjs/utf8@1.1.0':
-    optional: true
+  '@protobufjs/utf8@1.1.0': {}
 
   '@puppeteer/browsers@2.10.3':
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       extract-zip: 2.0.1
       progress: 2.0.3
       proxy-agent: 6.5.0
@@ -4721,10 +4994,6 @@ snapshots:
       - bare-buffer
       - react-native-b4a
       - supports-color
-
-  '@quansync/fs@1.0.0':
-    dependencies:
-      quansync: 1.0.0
 
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
     optional: true
@@ -4776,6 +5045,81 @@ snapshots:
     optional: true
 
   '@rolldown/pluginutils@1.0.0-rc.17': {}
+
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    optional: true
 
   '@shikijs/core@2.5.0':
     dependencies:
@@ -4846,26 +5190,15 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
-  '@types/cors@2.8.19':
-    dependencies:
-      '@types/node': 25.6.0
-
   '@types/deep-eql@4.0.2': {}
+
+  '@types/escodegen@0.0.10': {}
 
   '@types/estree@1.0.8': {}
 
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
-
-  '@types/jsdom@28.0.1':
-    dependencies:
-      '@types/node': 25.6.0
-      '@types/tough-cookie': 4.0.5
-      parse5: 7.3.0
-      undici-types: 7.25.0
-
-  '@types/jsesc@2.5.1': {}
 
   '@types/linkify-it@5.0.0': {}
 
@@ -4884,15 +5217,9 @@ snapshots:
     dependencies:
       undici-types: 7.19.2
 
-  '@types/tough-cookie@4.0.5': {}
-
   '@types/unist@3.0.3': {}
 
   '@types/web-bluetooth@0.0.21': {}
-
-  '@types/ws@8.18.1':
-    dependencies:
-      '@types/node': 25.6.0
 
   '@types/yauzl@2.10.3':
     dependencies:
@@ -4901,9 +5228,9 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-vue@5.2.4(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.3)(tsx@4.21.0))(vue@3.5.33(typescript@6.0.3))':
+  '@vitejs/plugin-vue@5.2.4(vite@5.4.21(@types/node@25.6.0)(lightningcss@1.32.0))(vue@3.5.33(typescript@6.0.3))':
     dependencies:
-      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.3)(tsx@4.21.0)
+      vite: 5.4.21(@types/node@25.6.0)(lightningcss@1.32.0)
       vue: 3.5.33(typescript@6.0.3)
 
   '@vitest/coverage-v8@4.1.5(vitest@4.1.5)':
@@ -4918,7 +5245,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.3)(tsx@4.21.0))
+      vitest: 4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.3)(tsx@4.16.1))
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -4929,13 +5256,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.3)(tsx@4.21.0))':
+  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.3)(tsx@4.16.1))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.3)(tsx@4.21.0)
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.3)(tsx@4.16.1)
 
   '@vitest/pretty-format@4.1.5':
     dependencies:
@@ -5044,12 +5371,13 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@vueuse/integrations@12.8.2(focus-trap@7.8.0)(typescript@6.0.3)':
+  '@vueuse/integrations@12.8.2(axios@1.15.0)(focus-trap@7.8.0)(typescript@6.0.3)':
     dependencies:
       '@vueuse/core': 12.8.2(typescript@6.0.3)
       '@vueuse/shared': 12.8.2(typescript@6.0.3)
       vue: 3.5.33(typescript@6.0.3)
     optionalDependencies:
+      axios: 1.15.0
       focus-trap: 7.8.0
     transitivePeerDependencies:
       - typescript
@@ -5062,17 +5390,12 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@whatwg-node/promise-helpers@1.3.2':
-    dependencies:
-      tslib: 2.8.1
-
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
-  adm-zip@0.5.17:
-    optional: true
+  adm-zip@0.5.17: {}
 
   agent-base@7.1.4: {}
 
@@ -5112,25 +5435,20 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
-  ansi-styles@6.2.3: {}
-
-  ansis@4.2.0: {}
-
-  asn1js@3.0.7:
+  anymatch@3.1.3:
     dependencies:
-      pvtsutils: 1.3.6
-      pvutils: 1.1.5
-      tslib: 2.8.1
+      normalize-path: 3.0.0
+      picomatch: 2.3.2
+
+  array-union@2.1.0: {}
 
   assertion-error@2.0.1: {}
 
-  ast-kit@3.0.0-beta.1:
-    dependencies:
-      '@babel/parser': 8.0.0-rc.3
-      estree-walker: 3.0.3
-      pathe: 2.0.3
-
   ast-types@0.13.4:
+    dependencies:
+      tslib: 2.8.1
+
+  ast-types@0.16.1:
     dependencies:
       tslib: 2.8.1
 
@@ -5140,16 +5458,19 @@ snapshots:
       estree-walker: 3.0.3
       js-tokens: 10.0.0
 
-  async-mutex@0.5.0:
+  asynckit@0.4.0: {}
+
+  axios@1.15.0:
     dependencies:
-      tslib: 2.8.1
+      follow-redirects: 1.15.11
+      form-data: 4.0.5
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
 
   b4a@1.8.0: {}
 
-  backo2@1.0.2: {}
-
-  balanced-match@4.0.4:
-    optional: true
+  balanced-match@4.0.4: {}
 
   bare-events@2.8.2: {}
 
@@ -5183,41 +5504,35 @@ snapshots:
     dependencies:
       bare-path: 3.0.0
 
-  base64-arraybuffer@1.0.2: {}
+  base64-js@1.5.1: {}
 
-  base64-js@1.5.1:
-    optional: true
+  baseline-browser-mapping@2.10.16: {}
 
-  baseline-browser-mapping@2.10.16:
-    optional: true
+  basic-ftp@5.2.1: {}
 
-  basic-ftp@5.3.0: {}
-
-  better-sqlite3@12.9.0:
+  better-sqlite3@12.8.0:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.3
-    optional: true
 
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
+    optional: true
+
+  binary-extensions@2.3.0: {}
 
   bindings@1.5.0:
     dependencies:
       file-uri-to-path: 1.0.0
-    optional: true
 
   birpc@2.9.0: {}
-
-  birpc@4.0.0: {}
 
   bl@4.1.0:
     dependencies:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
-    optional: true
 
   bluebird@3.7.2:
     optional: true
@@ -5226,7 +5541,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
@@ -5236,15 +5551,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  boolean@3.2.0:
-    optional: true
+  boolean@3.2.0: {}
 
   brace-expansion@5.0.5:
     dependencies:
       balanced-match: 4.0.4
-    optional: true
 
-  brotli-wasm@3.0.1: {}
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
 
   browserslist@4.28.2:
     dependencies:
@@ -5253,25 +5568,17 @@ snapshots:
       electron-to-chromium: 1.5.334
       node-releases: 2.0.37
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
-    optional: true
 
   buffer-crc32@0.2.13: {}
+
+  buffer-from@1.1.2: {}
 
   buffer@5.7.1:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
-    optional: true
-
-  bundle-name@4.1.0:
-    dependencies:
-      run-applescript: 7.1.0
 
   bytes@3.1.2: {}
-
-  cac@7.0.0: {}
-
-  cacheable-lookup@6.1.0: {}
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -5286,15 +5593,15 @@ snapshots:
   callsites@3.1.0:
     optional: true
 
-  camoufox-js@0.10.2(playwright-core@1.59.1):
+  camoufox-js@0.9.3(playwright-core@1.59.1):
     dependencies:
       adm-zip: 0.5.17
-      better-sqlite3: 12.9.0
+      better-sqlite3: 12.8.0
       cli-progress: 3.12.0
       commander: 14.0.3
       fingerprint-generator: 2.1.82
       glob: 13.0.6
-      impit: 0.13.1
+      impit: 0.11.0
       language-tags: 2.1.0
       maxmind: 5.0.6
       playwright-core: 1.59.1
@@ -5303,19 +5610,31 @@ snapshots:
       xml2js: 0.6.2
     optional: true
 
-  caniuse-lite@1.0.30001787:
-    optional: true
+  caniuse-lite@1.0.30001787: {}
 
   ccount@2.0.1: {}
 
   chai@6.2.2: {}
 
+  chalk@5.6.2: {}
+
   character-entities-html4@2.1.0: {}
 
   character-entities-legacy@3.0.0: {}
 
-  chownr@1.1.4:
-    optional: true
+  chokidar@3.6.0:
+    dependencies:
+      anymatch: 3.1.3
+      braces: 3.0.3
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  chownr@1.1.4: {}
 
   chromium-bidi@5.1.0(devtools-protocol@0.0.1439962):
     dependencies:
@@ -5323,10 +5642,16 @@ snapshots:
       mitt: 3.0.1
       zod: 3.25.76
 
+  cli-cursor@5.0.0:
+    dependencies:
+      restore-cursor: 5.1.0
+
   cli-progress@3.12.0:
     dependencies:
       string-width: 4.2.3
     optional: true
+
+  cli-spinners@3.4.0: {}
 
   cliui@8.0.1:
     dependencies:
@@ -5334,11 +5659,11 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
-  cliui@9.0.1:
+  clone-deep@4.0.1:
     dependencies:
-      string-width: 7.2.0
-      strip-ansi: 7.2.0
-      wrap-ansi: 9.0.2
+      is-plain-object: 2.0.4
+      kind-of: 6.0.3
+      shallow-clone: 3.0.1
 
   color-convert@2.0.1:
     dependencies:
@@ -5346,27 +5671,20 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   comma-separated-tokens@2.0.3: {}
 
   commander@12.1.0:
     optional: true
 
-  commander@14.0.3:
-    optional: true
+  commander@14.0.3: {}
 
-  commander@9.5.0:
-    optional: true
+  commander@9.5.0: {}
 
-  common-tags@1.8.2: {}
-
-  connect@3.7.0:
-    dependencies:
-      debug: 2.6.9
-      finalhandler: 1.1.2
-      parseurl: 1.3.3
-      utils-merge: 1.0.1
-    transitivePeerDependencies:
-      - supports-color
+  commondir@1.0.1: {}
 
   content-disposition@1.1.0: {}
 
@@ -5382,8 +5700,6 @@ snapshots:
     dependencies:
       is-what: 5.5.0
 
-  core-util-is@1.0.3: {}
-
   cors@2.8.6:
     dependencies:
       object-assign: 4.1.1
@@ -5393,10 +5709,6 @@ snapshots:
     dependencies:
       '@epic-web/invariant': 1.0.0
       cross-spawn: 7.0.6
-
-  cross-inspect@1.0.1:
-    dependencies:
-      tslib: 2.8.1
 
   cross-spawn@7.0.6:
     dependencies:
@@ -5408,6 +5720,7 @@ snapshots:
     dependencies:
       mdn-data: 2.27.1
       source-map-js: 1.2.1
+    optional: true
 
   csstype@3.2.3: {}
 
@@ -5419,54 +5732,39 @@ snapshots:
       whatwg-url: 16.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
-
-  debug@2.6.9:
-    dependencies:
-      ms: 2.0.0
+    optional: true
 
   debug@4.3.7:
     dependencies:
       ms: 2.1.3
     optional: true
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@5.5.0):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 5.5.0
 
-  decimal.js@10.6.0: {}
+  decimal.js@10.6.0:
+    optional: true
 
   decompress-response@6.0.0:
     dependencies:
       mimic-response: 3.1.0
-    optional: true
 
-  deep-extend@0.6.0:
-    optional: true
-
-  default-browser-id@5.0.1: {}
-
-  default-browser@5.5.0:
-    dependencies:
-      bundle-name: 4.1.0
-      default-browser-id: 5.0.1
+  deep-extend@0.6.0: {}
 
   define-data-property@1.1.4:
     dependencies:
       es-define-property: 1.0.1
       es-errors: 1.3.0
       gopd: 1.2.0
-    optional: true
-
-  define-lazy-prop@3.0.0: {}
 
   define-properties@1.2.1:
     dependencies:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
-    optional: true
-
-  defu@6.1.7: {}
 
   degenerator@5.0.1:
     dependencies:
@@ -5474,27 +5772,28 @@ snapshots:
       escodegen: 2.1.0
       esprima: 4.0.1
 
+  delayed-stream@1.0.0: {}
+
   depd@2.0.0: {}
 
   dequal@2.0.3: {}
-
-  destroyable-server@1.1.1:
-    dependencies:
-      '@types/node': 25.6.0
 
   detect-europe-js@0.1.2:
     optional: true
 
   detect-libc@2.1.2: {}
 
-  detect-node@2.1.0:
-    optional: true
+  detect-node@2.1.0: {}
 
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
 
   devtools-protocol@0.0.1439962: {}
+
+  dir-glob@3.0.1:
+    dependencies:
+      path-type: 4.0.0
 
   dot-prop@6.0.1:
     dependencies:
@@ -5503,35 +5802,19 @@ snapshots:
 
   dotenv@17.4.2: {}
 
-  dts-resolver@2.1.3: {}
-
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  duplexify@3.7.1:
-    dependencies:
-      end-of-stream: 1.4.5
-      inherits: 2.0.4
-      readable-stream: 2.3.8
-      stream-shift: 1.0.3
-
   ee-first@1.1.1: {}
 
-  electron-to-chromium@1.5.334:
-    optional: true
+  electron-to-chromium@1.5.334: {}
 
   emoji-regex-xs@1.0.0: {}
 
-  emoji-regex@10.6.0: {}
-
   emoji-regex@8.0.0: {}
-
-  empathic@2.0.0: {}
-
-  encodeurl@1.0.2: {}
 
   encodeurl@2.0.0: {}
 
@@ -5539,11 +5822,10 @@ snapshots:
     dependencies:
       once: 1.4.0
 
-  entities@6.0.1: {}
-
   entities@7.0.1: {}
 
-  entities@8.0.0: {}
+  entities@8.0.0:
+    optional: true
 
   es-define-property@1.0.1: {}
 
@@ -5555,8 +5837,14 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
 
-  es6-error@4.1.1:
-    optional: true
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
+
+  es6-error@4.1.1: {}
 
   esbuild@0.27.3:
     optionalDependencies:
@@ -5591,8 +5879,7 @@ snapshots:
 
   escape-html@1.0.3: {}
 
-  escape-string-regexp@4.0.0:
-    optional: true
+  escape-string-regexp@4.0.0: {}
 
   escodegen@2.1.0:
     dependencies:
@@ -5604,6 +5891,8 @@ snapshots:
 
   esprima@4.0.1: {}
 
+  estraverse@4.2.0: {}
+
   estraverse@5.3.0: {}
 
   estree-walker@2.0.2: {}
@@ -5612,11 +5901,11 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
+  esutils@2.0.2: {}
+
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
-
-  eventemitter3@3.1.2: {}
 
   events-universal@1.0.1:
     dependencies:
@@ -5630,8 +5919,7 @@ snapshots:
     dependencies:
       eventsource-parser: 3.0.6
 
-  expand-template@2.0.3:
-    optional: true
+  expand-template@2.0.3: {}
 
   expect-type@1.3.0: {}
 
@@ -5648,7 +5936,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
@@ -5675,7 +5963,7 @@ snapshots:
 
   extract-zip@2.0.1:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
@@ -5687,9 +5975,19 @@ snapshots:
 
   fast-fifo@1.3.2: {}
 
-  fast-json-patch@3.1.1: {}
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
 
   fast-uri@3.1.0: {}
+
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
 
   fd-slicer@1.1.0:
     dependencies:
@@ -5699,24 +5997,15 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
-  file-uri-to-path@1.0.0:
-    optional: true
+  file-uri-to-path@1.0.0: {}
 
-  finalhandler@1.1.2:
+  fill-range@7.1.1:
     dependencies:
-      debug: 2.6.9
-      encodeurl: 1.0.2
-      escape-html: 1.0.3
-      on-finished: 2.3.0
-      parseurl: 1.3.3
-      statuses: 1.5.0
-      unpipe: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
+      to-regex-range: 5.0.1
 
   finalhandler@2.1.1:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -5725,6 +6014,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  find-cache-dir@2.1.0:
+    dependencies:
+      commondir: 1.0.1
+      make-dir: 2.1.0
+      pkg-dir: 3.0.0
+
+  find-up@3.0.0:
+    dependencies:
+      locate-path: 3.0.0
+
   fingerprint-generator@2.1.82:
     dependencies:
       generative-bayesian-network: 2.1.82
@@ -5732,19 +6031,29 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  flatbuffers@25.9.23:
-    optional: true
+  flatbuffers@25.9.23: {}
+
+  flow-parser@0.309.0: {}
 
   focus-trap@7.8.0:
     dependencies:
       tabbable: 6.4.0
 
+  follow-redirects@1.15.11: {}
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+
   forwarded@0.2.0: {}
 
   fresh@2.0.0: {}
 
-  fs-constants@1.0.0:
-    optional: true
+  fs-constants@1.0.0: {}
 
   fsevents@2.3.3:
     optional: true
@@ -5757,8 +6066,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  gensync@1.0.0-beta.2:
-    optional: true
+  gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
 
@@ -5776,8 +6084,6 @@ snapshots:
       has-symbols: 1.1.0
       hasown: 2.0.2
       math-intrinsics: 1.1.0
-
-  get-port@7.2.0: {}
 
   get-proto@1.0.1:
     dependencies:
@@ -5798,14 +6104,17 @@ snapshots:
 
   get-uri@6.0.5:
     dependencies:
-      basic-ftp: 5.3.0
+      basic-ftp: 5.2.1
       data-uri-to-buffer: 6.0.2
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
-  github-from-package@0.0.0:
-    optional: true
+  github-from-package@0.0.0: {}
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
 
   glob@13.0.6:
     dependencies:
@@ -5822,43 +6131,42 @@ snapshots:
       roarr: 2.15.4
       semver: 7.7.4
       serialize-error: 7.0.1
-    optional: true
 
   globalthis@1.0.4:
     dependencies:
       define-properties: 1.2.1
       gopd: 1.2.0
-    optional: true
+
+  globby@11.1.0:
+    dependencies:
+      array-union: 2.1.0
+      dir-glob: 3.0.1
+      fast-glob: 3.3.3
+      ignore: 5.3.2
+      merge2: 1.4.1
+      slash: 3.0.0
 
   gopd@1.2.0: {}
 
-  graphql-http@1.22.4(graphql@15.10.2):
-    dependencies:
-      graphql: 15.10.2
+  graceful-fs@4.2.11: {}
 
-  graphql-subscriptions@2.0.0(graphql@15.10.2):
-    dependencies:
-      graphql: 15.10.2
-      iterall: 1.3.0
+  groq-sdk@1.1.2: {}
 
-  graphql-tag@2.12.6(graphql@15.10.2):
-    dependencies:
-      graphql: 15.10.2
-      tslib: 2.8.1
+  guid-typescript@1.0.9: {}
 
-  graphql@15.10.2: {}
-
-  guid-typescript@1.0.9:
-    optional: true
+  has-flag@3.0.0: {}
 
   has-flag@4.0.0: {}
 
   has-property-descriptors@1.0.2:
     dependencies:
       es-define-property: 1.0.1
-    optional: true
 
   has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
 
   hasown@2.0.2:
     dependencies:
@@ -5890,27 +6198,20 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  hono@4.12.14: {}
+  hono@4.12.7: {}
 
   hookable@5.5.3: {}
-
-  hookable@6.1.1: {}
 
   html-encoding-sniffer@6.0.0:
     dependencies:
       '@exodus/bytes': 1.15.0
     transitivePeerDependencies:
       - '@noble/hashes'
+    optional: true
 
   html-escaper@2.0.2: {}
 
   html-void-elements@3.0.0: {}
-
-  http-encoding@2.2.0:
-    dependencies:
-      brotli-wasm: 3.0.1
-      pify: 5.0.0
-      zstd-codec: 0.1.5
 
   http-errors@2.0.1:
     dependencies:
@@ -5923,19 +6224,14 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
-
-  http2-wrapper@2.2.1:
-    dependencies:
-      quick-lru: 5.1.1
-      resolve-alpn: 1.2.1
 
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -5943,94 +6239,101 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  ieee754@1.2.1:
+  ieee754@1.2.1: {}
+
+  ignore-by-default@1.0.1: {}
+
+  ignore@5.3.2: {}
+
+  impit-darwin-arm64@0.11.0:
     optional: true
 
-  impit-darwin-arm64@0.13.1:
+  impit-darwin-x64@0.11.0:
     optional: true
 
-  impit-darwin-x64@0.13.1:
+  impit-linux-arm64-gnu@0.11.0:
     optional: true
 
-  impit-linux-arm64-gnu@0.13.1:
+  impit-linux-arm64-musl@0.11.0:
     optional: true
 
-  impit-linux-arm64-musl@0.13.1:
+  impit-linux-x64-gnu@0.11.0:
     optional: true
 
-  impit-linux-x64-gnu@0.13.1:
+  impit-linux-x64-musl@0.11.0:
     optional: true
 
-  impit-linux-x64-musl@0.13.1:
+  impit-win32-arm64-msvc@0.11.0:
     optional: true
 
-  impit-win32-arm64-msvc@0.13.1:
+  impit-win32-x64-msvc@0.11.0:
     optional: true
 
-  impit-win32-x64-msvc@0.13.1:
-    optional: true
-
-  impit@0.13.1:
+  impit@0.11.0:
     optionalDependencies:
-      impit-darwin-arm64: 0.13.1
-      impit-darwin-x64: 0.13.1
-      impit-linux-arm64-gnu: 0.13.1
-      impit-linux-arm64-musl: 0.13.1
-      impit-linux-x64-gnu: 0.13.1
-      impit-linux-x64-musl: 0.13.1
-      impit-win32-arm64-msvc: 0.13.1
-      impit-win32-x64-msvc: 0.13.1
+      impit-darwin-arm64: 0.11.0
+      impit-darwin-x64: 0.11.0
+      impit-linux-arm64-gnu: 0.11.0
+      impit-linux-arm64-musl: 0.11.0
+      impit-linux-x64-gnu: 0.11.0
+      impit-linux-x64-musl: 0.11.0
+      impit-win32-arm64-msvc: 0.11.0
+      impit-win32-x64-msvc: 0.11.0
     optional: true
 
-  import-without-cache@0.3.3: {}
+  imurmurhash@0.1.4: {}
 
   inherits@2.0.4: {}
 
-  ini@1.3.8:
-    optional: true
+  ini@1.3.8: {}
 
   ip-address@10.1.0: {}
 
   ipaddr.js@1.9.1: {}
 
-  is-docker@3.0.0: {}
+  is-binary-path@2.1.0:
+    dependencies:
+      binary-extensions: 2.3.0
+
+  is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
 
-  is-in-ssh@1.0.0: {}
-
-  is-inside-container@1.0.0:
+  is-glob@4.0.3:
     dependencies:
-      is-docker: 3.0.0
+      is-extglob: 2.1.1
+
+  is-interactive@2.0.0: {}
+
+  is-number@7.0.0: {}
 
   is-obj@2.0.0:
     optional: true
 
-  is-potential-custom-element-name@1.0.1: {}
+  is-plain-object@2.0.4:
+    dependencies:
+      isobject: 3.0.1
+
+  is-potential-custom-element-name@1.0.1:
+    optional: true
 
   is-promise@4.0.0: {}
 
   is-standalone-pwa@0.1.1:
     optional: true
 
+  is-unicode-supported@2.1.0: {}
+
   is-what@5.5.0: {}
 
-  is-wsl@3.1.1:
-    dependencies:
-      is-inside-container: 1.0.0
-
-  isarray@1.0.0: {}
-
   isexe@2.0.0: {}
+
+  isobject@3.0.1: {}
 
   isolated-vm@6.1.2:
     dependencies:
       node-gyp-build: 4.8.4
     optional: true
-
-  isomorphic-ws@4.0.1(ws@8.20.0):
-    dependencies:
-      ws: 8.20.0
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -6045,13 +6348,34 @@ snapshots:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
 
-  iterall@1.3.0: {}
-
   jose@6.2.2: {}
 
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
+
+  jscodeshift@17.3.0:
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/parser': 7.29.2
+      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@7.29.0)
+      '@babel/preset-flow': 7.27.1(@babel/core@7.29.0)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
+      '@babel/register': 7.28.6(@babel/core@7.29.0)
+      flow-parser: 0.309.0
+      graceful-fs: 4.2.11
+      micromatch: 4.0.8
+      neo-async: 2.6.2
+      picocolors: 1.1.1
+      recast: 0.23.11
+      tmp: 0.2.5
+      write-file-atomic: 5.0.1
+    transitivePeerDependencies:
+      - supports-color
 
   jsdom@29.0.2:
     dependencies:
@@ -6078,6 +6402,7 @@ snapshots:
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
+    optional: true
 
   jsesc@3.1.0: {}
 
@@ -6085,11 +6410,11 @@ snapshots:
 
   json-schema-typed@8.0.2: {}
 
-  json-stringify-safe@5.0.1:
-    optional: true
+  json-stringify-safe@5.0.1: {}
 
-  json5@2.2.3:
-    optional: true
+  json5@2.2.3: {}
+
+  kind-of@6.0.3: {}
 
   koffi@2.16.1: {}
 
@@ -6193,20 +6518,29 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  limiter@3.0.0: {}
+
+  locate-path@3.0.0:
+    dependencies:
+      p-locate: 3.0.0
+      path-exists: 3.0.0
+
   lodash.isequal@4.5.0:
     optional: true
 
-  lodash@4.18.1: {}
+  log-symbols@7.0.1:
+    dependencies:
+      is-unicode-supported: 2.1.0
+      yoctocolors: 2.1.2
 
-  long@5.3.2:
+  long@5.3.2: {}
+
+  lru-cache@11.3.3:
     optional: true
-
-  lru-cache@11.3.3: {}
 
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
-    optional: true
 
   lru-cache@7.18.3: {}
 
@@ -6220,6 +6554,11 @@ snapshots:
       '@babel/types': 7.29.0
       source-map-js: 1.2.1
 
+  make-dir@2.1.0:
+    dependencies:
+      pify: 4.0.1
+      semver: 5.7.2
+
   make-dir@4.0.0:
     dependencies:
       semver: 7.7.4
@@ -6229,7 +6568,6 @@ snapshots:
   matcher@3.0.0:
     dependencies:
       escape-string-regexp: 4.0.0
-    optional: true
 
   math-intrinsics@1.1.0: {}
 
@@ -6251,13 +6589,16 @@ snapshots:
       unist-util-visit: 5.1.0
       vfile: 6.0.3
 
-  mdn-data@2.27.1: {}
+  mdn-data@2.27.1:
+    optional: true
 
   media-typer@1.1.0: {}
 
   medium-zoom@1.1.0: {}
 
   merge-descriptors@2.0.0: {}
+
+  merge2@1.4.1: {}
 
   micromark-util-character@2.1.1:
     dependencies:
@@ -6276,24 +6617,32 @@ snapshots:
 
   micromark-util-types@2.0.2: {}
 
-  milliparsec@5.1.1: {}
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.2
+
+  mime-db@1.52.0: {}
 
   mime-db@1.54.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
 
   mime-types@3.0.2:
     dependencies:
       mime-db: 1.54.0
 
-  mimic-response@3.1.0:
-    optional: true
+  mimic-function@5.0.1: {}
+
+  mimic-response@3.1.0: {}
 
   minimatch@10.2.4:
     dependencies:
       brace-expansion: 5.0.5
-    optional: true
 
-  minimist@1.2.8:
-    optional: true
+  minimist@1.2.8: {}
 
   minipass@7.1.3:
     optional: true
@@ -6302,79 +6651,32 @@ snapshots:
 
   mitt@3.0.1: {}
 
-  mkdirp-classic@0.5.3:
-    optional: true
+  mkdirp-classic@0.5.3: {}
 
   mmdb-lib@3.0.2:
     optional: true
 
-  mockttp@4.3.1:
-    dependencies:
-      '@graphql-tools/schema': 10.0.32(graphql@15.10.2)
-      '@graphql-tools/utils': 11.0.1(graphql@15.10.2)
-      '@httptoolkit/httpolyglot': 3.0.1
-      '@httptoolkit/subscriptions-transport-ws': 0.11.2(graphql@15.10.2)
-      '@httptoolkit/util': 0.1.9
-      '@httptoolkit/websocket-stream': 6.0.1
-      '@peculiar/asn1-pkcs8': 2.6.1
-      '@peculiar/asn1-schema': 2.6.0
-      '@peculiar/asn1-x509': 2.6.1
-      '@peculiar/x509': 1.14.3
-      '@types/cors': 2.8.19
-      '@types/node': 25.6.0
-      async-mutex: 0.5.0
-      base64-arraybuffer: 1.0.2
-      cacheable-lookup: 6.1.0
-      common-tags: 1.8.2
-      connect: 3.7.0
-      cors: 2.8.6
-      destroyable-server: 1.1.1
-      express: 5.2.1
-      fast-json-patch: 3.1.1
-      get-port: 7.2.0
-      graphql: 15.10.2
-      graphql-http: 1.22.4(graphql@15.10.2)
-      graphql-subscriptions: 2.0.0(graphql@15.10.2)
-      graphql-tag: 2.12.6(graphql@15.10.2)
-      http-encoding: 2.2.0
-      http2-wrapper: 2.2.1
-      https-proxy-agent: 7.0.6
-      isomorphic-ws: 4.0.1(ws@8.20.0)
-      lodash: 4.18.1
-      lru-cache: 11.3.3
-      milliparsec: 5.1.1
-      native-duplexpair: 1.0.0
-      pac-proxy-agent: 7.2.0
-      parse-multipart-data: 1.5.0
-      read-tls-client-hello: 2.0.0
-      semver: 7.7.4
-      socks-proxy-agent: 8.0.5
-      urlpattern-polyfill: 10.1.0
-      ws: 8.20.0
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  ms@2.0.0: {}
-
   ms@2.1.3: {}
+
+  multimap@1.0.2: {}
+
+  multimap@1.1.0: {}
+
+  mylas@2.1.14: {}
 
   nanoid@3.3.11: {}
 
-  napi-build-utils@2.0.0:
-    optional: true
-
-  native-duplexpair@1.0.0: {}
+  napi-build-utils@2.0.0: {}
 
   negotiator@1.0.0: {}
+
+  neo-async@2.6.2: {}
 
   netmask@2.1.1: {}
 
   node-abi@3.89.0:
     dependencies:
       semver: 7.7.4
-    optional: true
 
   node-forge@1.4.0:
     optional: true
@@ -6382,21 +6684,30 @@ snapshots:
   node-gyp-build@4.8.4:
     optional: true
 
-  node-releases@2.0.37:
-    optional: true
+  node-releases@2.0.37: {}
+
+  nodemon@3.1.14:
+    dependencies:
+      chokidar: 3.6.0
+      debug: 4.4.3(supports-color@5.5.0)
+      ignore-by-default: 1.0.1
+      minimatch: 10.2.4
+      pstree.remy: 1.1.8
+      semver: 7.7.4
+      simple-update-notifier: 2.0.0
+      supports-color: 5.5.0
+      touch: 3.1.1
+      undefsafe: 2.0.5
+
+  normalize-path@3.0.0: {}
 
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
 
-  object-keys@1.1.1:
-    optional: true
+  object-keys@1.1.1: {}
 
   obug@2.1.1: {}
-
-  on-finished@2.3.0:
-    dependencies:
-      ee-first: 1.1.1
 
   on-finished@2.4.1:
     dependencies:
@@ -6406,24 +6717,25 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  onetime@7.0.0:
+    dependencies:
+      mimic-function: 5.0.1
+
   oniguruma-to-es@3.1.1:
     dependencies:
       emoji-regex-xs: 1.0.0
       regex: 6.1.0
       regex-recursion: 6.0.2
 
-  onnxruntime-common@1.24.0-dev.20251116-b39e144322:
-    optional: true
+  onnxruntime-common@1.24.0-dev.20251116-b39e144322: {}
 
-  onnxruntime-common@1.24.3:
-    optional: true
+  onnxruntime-common@1.24.3: {}
 
   onnxruntime-node@1.24.3:
     dependencies:
       adm-zip: 0.5.17
       global-agent: 3.0.0
       onnxruntime-common: 1.24.3
-    optional: true
 
   onnxruntime-web@1.26.0-dev.20260416-b7804b056c:
     dependencies:
@@ -6432,17 +6744,23 @@ snapshots:
       long: 5.3.2
       onnxruntime-common: 1.24.0-dev.20251116-b39e144322
       platform: 1.3.6
-      protobufjs: 8.0.1
-    optional: true
+      protobufjs: 7.5.5
 
-  open@11.0.0:
+  openai@6.34.0(ws@8.20.0)(zod@4.3.6):
+    optionalDependencies:
+      ws: 8.20.0
+      zod: 4.3.6
+
+  ora@9.4.0:
     dependencies:
-      default-browser: 5.5.0
-      define-lazy-prop: 3.0.0
-      is-in-ssh: 1.0.0
-      is-inside-container: 1.0.0
-      powershell-utils: 0.1.0
-      wsl-utils: 0.3.1
+      chalk: 5.6.2
+      cli-cursor: 5.0.0
+      cli-spinners: 3.4.0
+      is-interactive: 2.0.0
+      is-unicode-supported: 2.1.0
+      log-symbols: 7.0.1
+      stdin-discarder: 0.3.2
+      string-width: 8.2.0
 
   ow@0.28.2:
     dependencies:
@@ -6453,29 +6771,29 @@ snapshots:
       vali-date: 1.0.0
     optional: true
 
-  oxfmt@0.46.0:
+  oxfmt@0.44.0:
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
-      '@oxfmt/binding-android-arm-eabi': 0.46.0
-      '@oxfmt/binding-android-arm64': 0.46.0
-      '@oxfmt/binding-darwin-arm64': 0.46.0
-      '@oxfmt/binding-darwin-x64': 0.46.0
-      '@oxfmt/binding-freebsd-x64': 0.46.0
-      '@oxfmt/binding-linux-arm-gnueabihf': 0.46.0
-      '@oxfmt/binding-linux-arm-musleabihf': 0.46.0
-      '@oxfmt/binding-linux-arm64-gnu': 0.46.0
-      '@oxfmt/binding-linux-arm64-musl': 0.46.0
-      '@oxfmt/binding-linux-ppc64-gnu': 0.46.0
-      '@oxfmt/binding-linux-riscv64-gnu': 0.46.0
-      '@oxfmt/binding-linux-riscv64-musl': 0.46.0
-      '@oxfmt/binding-linux-s390x-gnu': 0.46.0
-      '@oxfmt/binding-linux-x64-gnu': 0.46.0
-      '@oxfmt/binding-linux-x64-musl': 0.46.0
-      '@oxfmt/binding-openharmony-arm64': 0.46.0
-      '@oxfmt/binding-win32-arm64-msvc': 0.46.0
-      '@oxfmt/binding-win32-ia32-msvc': 0.46.0
-      '@oxfmt/binding-win32-x64-msvc': 0.46.0
+      '@oxfmt/binding-android-arm-eabi': 0.44.0
+      '@oxfmt/binding-android-arm64': 0.44.0
+      '@oxfmt/binding-darwin-arm64': 0.44.0
+      '@oxfmt/binding-darwin-x64': 0.44.0
+      '@oxfmt/binding-freebsd-x64': 0.44.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.44.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.44.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.44.0
+      '@oxfmt/binding-linux-arm64-musl': 0.44.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.44.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.44.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.44.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.44.0
+      '@oxfmt/binding-linux-x64-gnu': 0.44.0
+      '@oxfmt/binding-linux-x64-musl': 0.44.0
+      '@oxfmt/binding-openharmony-arm64': 0.44.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.44.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.44.0
+      '@oxfmt/binding-win32-x64-msvc': 0.44.0
 
   oxlint@1.61.0:
     optionalDependencies:
@@ -6499,11 +6817,21 @@ snapshots:
       '@oxlint/binding-win32-ia32-msvc': 1.61.0
       '@oxlint/binding-win32-x64-msvc': 1.61.0
 
+  p-limit@2.3.0:
+    dependencies:
+      p-try: 2.2.0
+
+  p-locate@3.0.0:
+    dependencies:
+      p-limit: 2.3.0
+
+  p-try@2.2.0: {}
+
   pac-proxy-agent@7.2.0:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       get-uri: 6.0.5
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -6517,17 +6845,14 @@ snapshots:
       degenerator: 5.0.1
       netmask: 2.1.1
 
-  parse-multipart-data@1.5.0: {}
-
-  parse5@7.3.0:
-    dependencies:
-      entities: 6.0.1
-
   parse5@8.0.1:
     dependencies:
       entities: 8.0.0
+    optional: true
 
   parseurl@1.3.3: {}
+
+  path-exists@3.0.0: {}
 
   path-key@3.1.1: {}
 
@@ -6539,6 +6864,8 @@ snapshots:
 
   path-to-regexp@8.4.0: {}
 
+  path-type@4.0.0: {}
+
   pathe@2.0.3: {}
 
   pend@1.2.0: {}
@@ -6547,25 +6874,34 @@ snapshots:
 
   picocolors@1.1.1: {}
 
+  picomatch@2.3.2: {}
+
   picomatch@4.0.4: {}
 
-  pify@5.0.0: {}
+  pify@4.0.1: {}
+
+  pirates@4.0.7: {}
 
   pkce-challenge@5.0.1: {}
 
-  platform@1.3.6:
-    optional: true
+  pkg-dir@3.0.0:
+    dependencies:
+      find-up: 3.0.0
+
+  platform@1.3.6: {}
 
   playwright-core@1.59.1:
     optional: true
+
+  plimit-lit@1.6.1:
+    dependencies:
+      queue-lit: 1.5.2
 
   postcss@8.5.10:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
-
-  powershell-utils@0.1.0: {}
 
   preact@10.29.1: {}
 
@@ -6583,18 +6919,15 @@ snapshots:
       simple-get: 4.0.1
       tar-fs: 2.1.4
       tunnel-agent: 0.6.0
-    optional: true
 
   pretty-bytes@7.1.0:
     optional: true
-
-  process-nextick-args@2.0.1: {}
 
   progress@2.0.3: {}
 
   property-information@7.1.0: {}
 
-  protobufjs@8.0.1:
+  protobufjs@7.5.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
@@ -6608,7 +6941,6 @@ snapshots:
       '@protobufjs/utf8': 1.1.0
       '@types/node': 25.6.0
       long: 5.3.2
-    optional: true
 
   proxy-addr@2.0.7:
     dependencies:
@@ -6618,7 +6950,7 @@ snapshots:
   proxy-agent@6.5.0:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       lru-cache: 7.18.3
@@ -6630,26 +6962,25 @@ snapshots:
 
   proxy-from-env@1.1.0: {}
 
+  proxy-from-env@2.1.0: {}
+
+  pstree.remy@1.1.8: {}
+
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
 
-  punycode@2.3.1: {}
-
-  pvtsutils@1.3.6:
-    dependencies:
-      tslib: 2.8.1
-
-  pvutils@1.1.5: {}
+  punycode@2.3.1:
+    optional: true
 
   qs@6.15.1:
     dependencies:
       side-channel: 1.1.0
 
-  quansync@1.0.0: {}
+  queue-lit@1.5.2: {}
 
-  quick-lru@5.1.1: {}
+  queue-microtask@1.2.3: {}
 
   quickjs-emscripten-core@0.32.0:
     dependencies:
@@ -6678,34 +7009,22 @@ snapshots:
       ini: 1.3.8
       minimist: 1.2.8
       strip-json-comments: 2.0.1
-    optional: true
-
-  read-tls-client-hello@2.0.0:
-    dependencies:
-      '@types/node': 25.6.0
-
-  readable-stream@2.3.8:
-    dependencies:
-      core-util-is: 1.0.3
-      inherits: 2.0.4
-      isarray: 1.0.0
-      process-nextick-args: 2.0.1
-      safe-buffer: 5.1.2
-      string_decoder: 1.1.1
-      util-deprecate: 1.0.2
 
   readable-stream@3.6.2:
     dependencies:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
-    optional: true
+
+  readdirp@3.6.0:
+    dependencies:
+      picomatch: 2.3.2
 
   rebrowser-puppeteer-core@24.8.1:
     dependencies:
       '@puppeteer/browsers': 2.10.3
       chromium-bidi: 5.1.0(devtools-protocol@0.0.1439962)
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       devtools-protocol: 0.0.1439962
       typed-query-selector: 2.12.1
       ws: 8.20.0
@@ -6717,7 +7036,13 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  reflect-metadata@0.2.2: {}
+  recast@0.23.11:
+    dependencies:
+      ast-types: 0.16.1
+      esprima: 4.0.1
+      source-map: 0.6.1
+      tiny-invariant: 1.3.3
+      tslib: 2.8.1
 
   regex-recursion@6.0.2:
     dependencies:
@@ -6733,9 +7058,14 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
-  resolve-alpn@1.2.1: {}
-
   resolve-pkg-maps@1.0.0: {}
+
+  restore-cursor@5.1.0:
+    dependencies:
+      onetime: 7.0.0
+      signal-exit: 4.1.0
+
+  reusify@1.1.0: {}
 
   rfdc@1.4.1: {}
 
@@ -6747,25 +7077,6 @@ snapshots:
       json-stringify-safe: 5.0.1
       semver-compare: 1.0.0
       sprintf-js: 1.1.3
-    optional: true
-
-  rolldown-plugin-dts@0.23.2(rolldown@1.0.0-rc.17)(typescript@6.0.3):
-    dependencies:
-      '@babel/generator': 8.0.0-rc.3
-      '@babel/helper-validator-identifier': 8.0.0-rc.3
-      '@babel/parser': 8.0.0-rc.3
-      '@babel/types': 8.0.0-rc.3
-      ast-kit: 3.0.0-beta.1
-      birpc: 4.0.0
-      dts-resolver: 2.1.3
-      get-tsconfig: 4.14.0
-      obug: 2.1.1
-      picomatch: 4.0.4
-      rolldown: 1.0.0-rc.17
-    optionalDependencies:
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - oxc-resolver
 
   rolldown@1.0.0-rc.17:
     dependencies:
@@ -6788,18 +7099,40 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
 
-  rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.17):
+  rollup@4.60.2:
     dependencies:
-      open: 11.0.0
-      picomatch: 4.0.4
-      source-map: 0.7.6
-      yargs: 18.0.0
+      '@types/estree': 1.0.8
     optionalDependencies:
-      rolldown: 1.0.0-rc.17
+      '@rollup/rollup-android-arm-eabi': 4.60.2
+      '@rollup/rollup-android-arm64': 4.60.2
+      '@rollup/rollup-darwin-arm64': 4.60.2
+      '@rollup/rollup-darwin-x64': 4.60.2
+      '@rollup/rollup-freebsd-arm64': 4.60.2
+      '@rollup/rollup-freebsd-x64': 4.60.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.2
+      '@rollup/rollup-linux-arm64-gnu': 4.60.2
+      '@rollup/rollup-linux-arm64-musl': 4.60.2
+      '@rollup/rollup-linux-loong64-gnu': 4.60.2
+      '@rollup/rollup-linux-loong64-musl': 4.60.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.2
+      '@rollup/rollup-linux-ppc64-musl': 4.60.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.2
+      '@rollup/rollup-linux-riscv64-musl': 4.60.2
+      '@rollup/rollup-linux-s390x-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-musl': 4.60.2
+      '@rollup/rollup-openbsd-x64': 4.60.2
+      '@rollup/rollup-openharmony-arm64': 4.60.2
+      '@rollup/rollup-win32-arm64-msvc': 4.60.2
+      '@rollup/rollup-win32-ia32-msvc': 4.60.2
+      '@rollup/rollup-win32-x64-gnu': 4.60.2
+      '@rollup/rollup-win32-x64-msvc': 4.60.2
+      fsevents: 2.3.3
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -6807,9 +7140,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  run-applescript@7.1.0: {}
-
-  safe-buffer@5.1.2: {}
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
 
   safe-buffer@5.2.1: {}
 
@@ -6821,20 +7154,21 @@ snapshots:
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
+    optional: true
 
   search-insights@2.17.3: {}
 
-  semver-compare@1.0.0:
-    optional: true
+  semver-compare@1.0.0: {}
 
-  semver@6.3.1:
-    optional: true
+  semver@5.7.2: {}
+
+  semver@6.3.1: {}
 
   semver@7.7.4: {}
 
   send@1.2.1:
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -6851,7 +7185,6 @@ snapshots:
   serialize-error@7.0.1:
     dependencies:
       type-fest: 0.13.1
-    optional: true
 
   serve-static@2.2.1:
     dependencies:
@@ -6863,6 +7196,10 @@ snapshots:
       - supports-color
 
   setprototypeof@1.2.0: {}
+
+  shallow-clone@3.0.1:
+    dependencies:
+      kind-of: 6.0.3
 
   sharp@0.34.5:
     dependencies:
@@ -6894,13 +7231,103 @@ snapshots:
       '@img/sharp-win32-arm64': 0.34.5
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
-    optional: true
 
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  shift-ast@5.0.0: {}
+
+  shift-ast@6.0.0: {}
+
+  shift-ast@6.1.0: {}
+
+  shift-ast@7.0.0: {}
+
+  shift-parser@7.0.3:
+    dependencies:
+      multimap: 1.1.0
+      shift-ast: 6.0.0
+      shift-reducer: 6.0.0
+      shift-regexp-acceptor: 2.0.3
+
+  shift-parser@8.0.0:
+    dependencies:
+      multimap: 1.1.0
+      shift-ast: 7.0.0
+      shift-reducer: 7.0.0
+      shift-regexp-acceptor: 3.0.0
+
+  shift-printer@1.0.1:
+    dependencies:
+      '@jsoverson/shift-codegen': 7.0.0
+
+  shift-query@1.0.2:
+    dependencies:
+      shift-traverser: 1.0.0
+
+  shift-reducer@5.0.0:
+    dependencies:
+      shift-ast: 5.0.0
+
+  shift-reducer@6.0.0:
+    dependencies:
+      shift-ast: 6.0.0
+
+  shift-reducer@7.0.0:
+    dependencies:
+      shift-ast: 7.0.0
+
+  shift-refactor@2.0.0:
+    dependencies:
+      '@jsoverson/shift-codegen': 7.0.0
+      debug: 4.4.3(supports-color@5.5.0)
+      fast-deep-equal: 3.1.3
+      shift-ast: 6.1.0
+      shift-parser: 7.0.3
+      shift-printer: 1.0.1
+      shift-query: 1.0.2
+      shift-scope: 4.0.0
+      shift-traverser: 1.0.0
+      shift-validator: 5.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  shift-regexp-acceptor@2.0.3:
+    dependencies:
+      unicode-match-property-ecmascript: 1.0.4
+      unicode-match-property-value-ecmascript: 1.0.2
+      unicode-property-aliases-ecmascript: 1.0.4
+
+  shift-regexp-acceptor@3.0.0:
+    dependencies:
+      unicode-match-property-ecmascript: 1.0.4
+      unicode-match-property-value-ecmascript: 1.0.2
+      unicode-property-aliases-ecmascript: 1.0.4
+
+  shift-scope@4.0.0:
+    dependencies:
+      multimap: 1.0.2
+      shift-reducer: 5.0.0
+      shift-spec: 2017.0.0
+
+  shift-spec@2017.0.0: {}
+
+  shift-spec@2018.0.0: {}
+
+  shift-traverser@1.0.0:
+    dependencies:
+      estraverse: 4.2.0
+      shift-spec: 2018.0.0
+
+  shift-validator@5.0.1:
+    dependencies:
+      esutils: 2.0.2
+      shift-parser: 7.0.3
+      shift-reducer: 6.0.0
+      shift-regexp-acceptor: 2.0.3
 
   shiki@2.5.0:
     dependencies:
@@ -6943,22 +7370,28 @@ snapshots:
 
   siginfo@2.0.0: {}
 
-  simple-concat@1.0.1:
-    optional: true
+  signal-exit@4.1.0: {}
+
+  simple-concat@1.0.1: {}
 
   simple-get@4.0.1:
     dependencies:
       decompress-response: 6.0.0
       once: 1.4.0
       simple-concat: 1.0.1
-    optional: true
+
+  simple-update-notifier@2.0.0:
+    dependencies:
+      semver: 7.7.4
+
+  slash@3.0.0: {}
 
   smart-buffer@4.2.0: {}
 
   socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       socks: 2.8.7
     transitivePeerDependencies:
       - supports-color
@@ -6970,10 +7403,12 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map@0.6.1:
-    optional: true
+  source-map-support@0.5.21:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
 
-  source-map@0.7.6: {}
+  source-map@0.6.1: {}
 
   space-separated-tokens@2.0.2: {}
 
@@ -6984,18 +7419,15 @@ snapshots:
       through: 2.3.8
     optional: true
 
-  sprintf-js@1.1.3:
-    optional: true
+  sprintf-js@1.1.3: {}
 
   stackback@0.0.2: {}
-
-  statuses@1.5.0: {}
 
   statuses@2.0.2: {}
 
   std-env@4.1.0: {}
 
-  stream-shift@1.0.3: {}
+  stdin-discarder@0.3.2: {}
 
   streamx@2.25.0:
     dependencies:
@@ -7012,20 +7444,14 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
-  string-width@7.2.0:
+  string-width@8.2.0:
     dependencies:
-      emoji-regex: 10.6.0
       get-east-asian-width: 1.5.0
       strip-ansi: 7.2.0
-
-  string_decoder@1.1.1:
-    dependencies:
-      safe-buffer: 5.1.2
 
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
-    optional: true
 
   stringify-entities@4.0.4:
     dependencies:
@@ -7040,20 +7466,22 @@ snapshots:
     dependencies:
       ansi-regex: 6.2.2
 
-  strip-json-comments@2.0.1:
-    optional: true
+  strip-json-comments@2.0.1: {}
 
   superjson@2.2.6:
     dependencies:
       copy-anything: 4.0.5
 
+  supports-color@5.5.0:
+    dependencies:
+      has-flag: 3.0.0
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
 
-  symbol-observable@1.2.0: {}
-
-  symbol-tree@3.2.4: {}
+  symbol-tree@3.2.4:
+    optional: true
 
   tabbable@6.4.0: {}
 
@@ -7063,7 +7491,6 @@ snapshots:
       mkdirp-classic: 0.5.3
       pump: 3.0.4
       tar-stream: 2.2.0
-    optional: true
 
   tar-fs@3.1.2:
     dependencies:
@@ -7084,7 +7511,6 @@ snapshots:
       fs-constants: 1.0.0
       inherits: 2.0.4
       readable-stream: 3.6.2
-    optional: true
 
   tar-stream@3.1.8:
     dependencies:
@@ -7113,6 +7539,8 @@ snapshots:
   through@2.3.8:
     optional: true
 
+  tiny-invariant@1.3.3: {}
+
   tiny-lru@13.0.0:
     optional: true
 
@@ -7129,75 +7557,60 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
-  tldts-core@7.0.28: {}
+  tldts-core@7.0.28:
+    optional: true
 
   tldts@7.0.28:
     dependencies:
       tldts-core: 7.0.28
+    optional: true
+
+  tmp@0.2.5: {}
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
 
   toidentifier@1.0.1: {}
+
+  touch@3.1.1: {}
 
   tough-cookie@6.0.1:
     dependencies:
       tldts: 7.0.28
+    optional: true
 
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
-
-  tree-kill@1.2.2: {}
+    optional: true
 
   trim-lines@3.0.1: {}
 
-  tsdown@0.21.10(typescript@6.0.3):
+  tsc-alias@1.8.16:
     dependencies:
-      ansis: 4.2.0
-      cac: 7.0.0
-      defu: 6.1.7
-      empathic: 2.0.0
-      hookable: 6.1.1
-      import-without-cache: 0.3.3
-      obug: 2.1.1
-      picomatch: 4.0.4
-      rolldown: 1.0.0-rc.17
-      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.17)(typescript@6.0.3)
-      semver: 7.7.4
-      tinyexec: 1.1.1
-      tinyglobby: 0.2.16
-      tree-kill: 1.2.2
-      unconfig-core: 7.5.0
-      unrun: 0.2.37
-    optionalDependencies:
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - '@ts-macro/tsc'
-      - '@typescript/native-preview'
-      - oxc-resolver
-      - synckit
-      - vue-tsc
-
-  tslib@1.14.1: {}
+      chokidar: 3.6.0
+      commander: 9.5.0
+      get-tsconfig: 4.14.0
+      globby: 11.1.0
+      mylas: 2.1.14
+      normalize-path: 3.0.0
+      plimit-lit: 1.6.1
 
   tslib@2.8.1: {}
 
-  tsx@4.21.0:
+  tsx@4.16.1:
     dependencies:
       esbuild: 0.27.3
       get-tsconfig: 4.13.7
     optionalDependencies:
       fsevents: 2.3.3
 
-  tsyringe@4.10.0:
-    dependencies:
-      tslib: 1.14.1
-
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
-    optional: true
 
-  type-fest@0.13.1:
-    optional: true
+  type-fest@0.13.1: {}
 
   type-is@2.0.1:
     dependencies:
@@ -7219,16 +7632,23 @@ snapshots:
       ua-is-frozen: 0.1.2
     optional: true
 
-  unconfig-core@7.5.0:
-    dependencies:
-      '@quansync/fs': 1.0.0
-      quansync: 1.0.0
+  undefsafe@2.0.5: {}
 
   undici-types@7.19.2: {}
 
-  undici-types@7.25.0: {}
+  undici@7.25.0:
+    optional: true
 
-  undici@7.25.0: {}
+  unicode-canonical-property-names-ecmascript@1.0.4: {}
+
+  unicode-match-property-ecmascript@1.0.4:
+    dependencies:
+      unicode-canonical-property-names-ecmascript: 1.0.4
+      unicode-property-aliases-ecmascript: 1.0.4
+
+  unicode-match-property-value-ecmascript@1.0.2: {}
+
+  unicode-property-aliases-ecmascript@1.0.4: {}
 
   unist-util-is@6.0.1:
     dependencies:
@@ -7255,22 +7675,13 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unrun@0.2.37:
-    dependencies:
-      rolldown: 1.0.0-rc.17
-
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
       browserslist: 4.28.2
       escalade: 3.2.0
       picocolors: 1.1.1
-    optional: true
-
-  urlpattern-polyfill@10.1.0: {}
 
   util-deprecate@1.0.2: {}
-
-  utils-merge@1.0.1: {}
 
   vali-date@1.0.0:
     optional: true
@@ -7287,7 +7698,17 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.3)(tsx@4.21.0):
+  vite@5.4.21(@types/node@25.6.0)(lightningcss@1.32.0):
+    dependencies:
+      esbuild: 0.27.3
+      postcss: 8.5.10
+      rollup: 4.60.2
+    optionalDependencies:
+      '@types/node': 25.6.0
+      fsevents: 2.3.3
+      lightningcss: 1.32.0
+
+  vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.3)(tsx@4.16.1):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -7298,9 +7719,9 @@ snapshots:
       '@types/node': 25.6.0
       esbuild: 0.27.3
       fsevents: 2.3.3
-      tsx: 4.21.0
+      tsx: 4.16.1
 
-  vitepress@1.6.4(@algolia/client-search@5.50.1)(@types/node@25.6.0)(esbuild@0.27.3)(postcss@8.5.10)(search-insights@2.17.3)(tsx@4.21.0)(typescript@6.0.3):
+  vitepress@1.6.4(@algolia/client-search@5.50.1)(@types/node@25.6.0)(axios@1.15.0)(lightningcss@1.32.0)(postcss@8.5.10)(search-insights@2.17.3)(typescript@6.0.3):
     dependencies:
       '@docsearch/css': 3.8.2
       '@docsearch/js': 3.8.2(@algolia/client-search@5.50.1)(search-insights@2.17.3)
@@ -7309,16 +7730,16 @@ snapshots:
       '@shikijs/transformers': 2.5.0
       '@shikijs/types': 2.5.0
       '@types/markdown-it': 14.1.2
-      '@vitejs/plugin-vue': 5.2.4(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.3)(tsx@4.21.0))(vue@3.5.33(typescript@6.0.3))
+      '@vitejs/plugin-vue': 5.2.4(vite@5.4.21(@types/node@25.6.0)(lightningcss@1.32.0))(vue@3.5.33(typescript@6.0.3))
       '@vue/devtools-api': 7.7.9
       '@vue/shared': 3.5.32
       '@vueuse/core': 12.8.2(typescript@6.0.3)
-      '@vueuse/integrations': 12.8.2(focus-trap@7.8.0)(typescript@6.0.3)
+      '@vueuse/integrations': 12.8.2(axios@1.15.0)(focus-trap@7.8.0)(typescript@6.0.3)
       focus-trap: 7.8.0
       mark.js: 8.11.1
       minisearch: 7.2.0
       shiki: 2.5.0
-      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.3)(tsx@4.21.0)
+      vite: 5.4.21(@types/node@25.6.0)(lightningcss@1.32.0)
       vue: 3.5.33(typescript@6.0.3)
     optionalDependencies:
       postcss: 8.5.10
@@ -7326,17 +7747,15 @@ snapshots:
       - '@algolia/client-search'
       - '@types/node'
       - '@types/react'
-      - '@vitejs/devtools'
       - async-validator
       - axios
       - change-case
       - drauu
-      - esbuild
       - fuse.js
       - idb-keyval
-      - jiti
       - jwt-decode
       - less
+      - lightningcss
       - nprogress
       - qrcode
       - react
@@ -7348,15 +7767,13 @@ snapshots:
       - stylus
       - sugarss
       - terser
-      - tsx
       - typescript
       - universal-cookie
-      - yaml
 
-  vitest@4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.3)(tsx@4.21.0)):
+  vitest@4.1.5(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(jsdom@29.0.2)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.3)(tsx@4.16.1)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.3)(tsx@4.21.0))
+      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.3)(tsx@4.16.1))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -7373,7 +7790,7 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.3)(tsx@4.21.0)
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.3)(tsx@4.16.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.6.0
@@ -7395,6 +7812,7 @@ snapshots:
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
+    optional: true
 
   webcrack@2.15.1:
     dependencies:
@@ -7406,15 +7824,17 @@ snapshots:
       '@babel/types': 7.29.0
       '@codemod/matchers': 1.7.1
       commander: 12.1.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@5.5.0)
       isolated-vm: 6.1.2
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  webidl-conversions@8.0.1: {}
+  webidl-conversions@8.0.1:
+    optional: true
 
-  whatwg-mimetype@5.0.0: {}
+  whatwg-mimetype@5.0.0:
+    optional: true
 
   whatwg-url@16.0.1:
     dependencies:
@@ -7423,6 +7843,7 @@ snapshots:
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
+    optional: true
 
   which@2.0.2:
     dependencies:
@@ -7439,22 +7860,17 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
-  wrap-ansi@9.0.2:
-    dependencies:
-      ansi-styles: 6.2.3
-      string-width: 7.2.0
-      strip-ansi: 7.2.0
-
   wrappy@1.0.2: {}
+
+  write-file-atomic@5.0.1:
+    dependencies:
+      imurmurhash: 0.1.4
+      signal-exit: 4.1.0
 
   ws@8.20.0: {}
 
-  wsl-utils@0.3.1:
-    dependencies:
-      is-wsl: 3.1.1
-      powershell-utils: 0.1.0
-
-  xml-name-validator@5.0.0: {}
+  xml-name-validator@5.0.0:
+    optional: true
 
   xml2js@0.6.2:
     dependencies:
@@ -7465,18 +7881,14 @@ snapshots:
   xmlbuilder@11.0.1:
     optional: true
 
-  xmlchars@2.2.0: {}
-
-  xtend@4.0.2: {}
+  xmlchars@2.2.0:
+    optional: true
 
   y18n@5.0.8: {}
 
-  yallist@3.1.1:
-    optional: true
+  yallist@3.1.1: {}
 
   yargs-parser@21.1.1: {}
-
-  yargs-parser@22.0.0: {}
 
   yargs@17.7.2:
     dependencies:
@@ -7488,19 +7900,12 @@ snapshots:
       y18n: 5.0.8
       yargs-parser: 21.1.1
 
-  yargs@18.0.0:
-    dependencies:
-      cliui: 9.0.1
-      escalade: 3.2.0
-      get-caller-file: 2.0.5
-      string-width: 7.2.0
-      y18n: 5.0.8
-      yargs-parser: 22.0.0
-
   yauzl@2.10.0:
     dependencies:
       buffer-crc32: 0.2.13
       fd-slicer: 1.1.0
+
+  yoctocolors@2.1.2: {}
 
   zod-to-json-schema@3.25.2(zod@4.3.6):
     dependencies:
@@ -7509,7 +7914,5 @@ snapshots:
   zod@3.25.76: {}
 
   zod@4.3.6: {}
-
-  zstd-codec@0.1.5: {}
 
   zwitch@2.0.4: {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,8 +69,32 @@ function formatUnknownError(input: unknown): string {
   }
 }
 
-export async function main(): Promise<void> {
+/**
+ * Parse CLI arguments to extract Pro API configuration flags.
+ * Sets process environment variables for proApiToken and proApiVersion.
+ */
+function parseProApiFlags(args: string[]): void {
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--pro-api-token' && args[i + 1]) {
+      const token = args[i + 1]!;
+      if (token.length < 10) {
+        console.error('[ERROR] --pro-api-token must be at least 10 characters');
+        process.exit(1);
+      }
+      process.env.OBFUSCATOR_IO_API_TOKEN = token;
+      i++; // Skip the value argument
+    } else if (args[i] === '--pro-api-version' && args[i + 1]) {
+      process.env.OBFUSCATOR_IO_VERSION = args[i + 1];
+      i++; // Skip the value argument
+    }
+  }
+}
+
+export async function main() {
   try {
+    // Parse Pro API flags before fast path to set environment variables
+    parseProApiFlags(process.argv.slice(2));
+
     const cliFastPath = resolveCliFastPath(process.argv.slice(2), import.meta.url);
     if (cliFastPath.handled) {
       if (cliFastPath.output) {
@@ -102,16 +126,7 @@ export async function main(): Promise<void> {
     }
 
     logger.info('Creating MCP server instance...');
-    const explicitProfile = (process.env.MCP_TOOL_PROFILE ?? '').trim().toLowerCase() as
-      | 'search'
-      | 'workflow'
-      | 'full'
-      | undefined;
-    const profile =
-      explicitProfile === 'full' || explicitProfile === 'workflow' || explicitProfile === 'search'
-        ? explicitProfile
-        : 'search';
-    await initRegistry(profile);
+    await initRegistry();
     const server = new MCPServer(config);
     const stopArtifactRetentionScheduler = startArtifactRetentionScheduler();
     const recoveryWindowMs = Math.max(1000, RUNTIME_ERROR_WINDOW_MS);

--- a/src/modules/deobfuscator/ASTOptimizer.ts
+++ b/src/modules/deobfuscator/ASTOptimizer.ts
@@ -1,50 +1,25 @@
 import * as parser from '@babel/parser';
 import traverse from '@babel/traverse';
-import type { NodePath } from '@babel/traverse';
 import generate from '@babel/generator';
 import * as t from '@babel/types';
 import { logger } from '@utils/logger';
 
 export class ASTOptimizer {
-  optimize(
-    code: string,
-    options?: { onProgress?: (progress: number, total?: number) => void },
-  ): string {
+  optimize(code: string): string {
     try {
       const ast = parser.parse(code, {
-        sourceType: 'module',
+        sourceType: 'unambiguous',
         plugins: ['jsx', 'typescript'],
+        errorRecovery: true,
       });
 
-      const totalSteps = 3 * 8; // 3 passes * 8 traversals
-      let currentStep = 0;
-
-      for (let i = 0; i < 3; i++) {
+      for (let i = 0; i < 4; i++) {
         logger.debug(`AST optimization pass ${i + 1}`);
 
-        this.constantFolding(ast);
-        options?.onProgress?.(++currentStep, totalSteps);
-
-        this.constantPropagation(ast);
-        options?.onProgress?.(++currentStep, totalSteps);
-
-        this.deadCodeElimination(ast);
-        options?.onProgress?.(++currentStep, totalSteps);
-
-        this.expressionSimplification(ast);
-        options?.onProgress?.(++currentStep, totalSteps);
-
-        this.variableInlining(ast);
-        options?.onProgress?.(++currentStep, totalSteps);
-
-        this.objectPropertyUnfolding(ast);
-        options?.onProgress?.(++currentStep, totalSteps);
-
-        this.computedPropertyResolution(ast);
-        options?.onProgress?.(++currentStep, totalSteps);
-
-        this.sequenceExpressionExpansion(ast);
-        options?.onProgress?.(++currentStep, totalSteps);
+        this.passLiteralAndUnaryOps(ast);
+        this.applyInlineAndFold(ast);
+        this.passControlFlowAndStatements(ast);
+        this.passObjectAndSequenceOps(ast);
       }
 
       const output = generate(ast, {
@@ -54,19 +29,197 @@ export class ASTOptimizer {
 
       return output.code;
     } catch (error) {
-      logger.error('AST optimization failed', error);
-      return code;
+      const errorDetails = {
+        error: 'ASTOptimizationFailed',
+        message: error instanceof Error ? error.message : 'Unknown error',
+        timestamp: new Date().toISOString(),
+        context: {
+          codePreview: code.substring(0, 500),
+        },
+      };
+      logger.error(`AST optimization failed: ${JSON.stringify(errorDetails)}`);
+      throw new Error(JSON.stringify(errorDetails));
     }
   }
 
-  private constantFolding(ast: t.File): void {
+  private passLiteralAndUnaryOps(ast: t.File): void {
     traverse(ast, {
+      NumericLiteral(path) {
+        const raw = path.node.extra?.raw as string | undefined;
+        if (raw && /^0x[0-9a-fA-F]+$/.test(raw)) {
+          const node = t.numericLiteral(path.node.value);
+          node.extra = { raw: String(path.node.value), rawValue: path.node.value };
+          path.replaceWith(node);
+        }
+      },
+
+      StringLiteral(path) {
+        const raw = path.node.extra?.raw as string | undefined;
+        if (raw && /\\u[0-9a-fA-F]{4}/.test(raw)) {
+          path.replaceWith(t.stringLiteral(path.node.value));
+        }
+      },
+
+      UnaryExpression(path) {
+        const { argument, operator } = path.node;
+
+        if (operator === 'void' && t.isNumericLiteral(argument) && argument.value === 0) {
+          path.replaceWith(t.identifier('undefined'));
+          return;
+        }
+
+        if (t.isNumericLiteral(argument)) {
+          if (operator === '-') {
+            path.replaceWith(t.numericLiteral(-argument.value));
+            return;
+          }
+          if (operator === '+') {
+            path.replaceWith(t.numericLiteral(argument.value));
+            return;
+          }
+          if (operator === '!') {
+            path.replaceWith(t.booleanLiteral(!argument.value));
+            return;
+          }
+          if (operator === '~') {
+            path.replaceWith(t.numericLiteral(~argument.value));
+            return;
+          }
+        }
+
+        if (t.isBooleanLiteral(argument) && operator === '!') {
+          path.replaceWith(t.booleanLiteral(!argument.value));
+          return;
+        }
+
+        if (operator === '!' && t.isUnaryExpression(argument) && argument.operator === '!') {
+          if (t.isLiteral(argument.argument)) {
+            const val = (argument.argument as t.NumericLiteral | t.StringLiteral | t.BooleanLiteral)
+              .value;
+            path.replaceWith(t.booleanLiteral(Boolean(val)));
+          }
+        }
+      },
+
       BinaryExpression(path) {
         const { left, right, operator } = path.node;
 
-        if (t.isNumericLiteral(left) && t.isNumericLiteral(right)) {
-          let result: number;
+        if (
+          ['===', '!==', '==', '!='].includes(operator) &&
+          t.isUnaryExpression(left) &&
+          left.operator === 'typeof' &&
+          t.isStringLiteral(right)
+        ) {
+          const validTypes = [
+            'undefined',
+            'boolean',
+            'number',
+            'string',
+            'object',
+            'function',
+            'symbol',
+            'bigint',
+          ];
+          if (!validTypes.includes(right.value)) {
+            path.replaceWith(t.booleanLiteral(false));
+          }
+        }
+      },
+    });
+  }
 
+  private collectConstants(ast: t.File): Map<string, t.Expression> {
+    const constants = new Map<string, t.Expression>();
+    traverse(ast, {
+      VariableDeclarator(vDeclPath) {
+        const { id, init } = vDeclPath.node;
+        if (t.isIdentifier(id) && init && t.isLiteral(init)) {
+          const binding = vDeclPath.scope.getBinding(id.name);
+          if (binding && !binding.constantViolations.length) {
+            constants.set(id.name, init);
+          }
+        }
+      },
+    });
+    return constants;
+  }
+
+  private collectInlineCandidates(
+    ast: t.File,
+  ): Map<string, { value: t.Expression; usageCount: number }> {
+    const inlineCandidates = new Map<string, { value: t.Expression; usageCount: number }>();
+
+    traverse(ast, {
+      VariableDeclarator(vDeclPath) {
+        const { id, init } = vDeclPath.node;
+        if (t.isIdentifier(id) && init && t.isLiteral(init)) {
+          inlineCandidates.set(id.name, { value: init, usageCount: 0 });
+        }
+      },
+    });
+
+    return inlineCandidates;
+  }
+
+  private countInlineUsages(
+    ast: t.File,
+    inlineCandidates: Map<string, { value: t.Expression; usageCount: number }>,
+  ): void {
+    traverse(ast, {
+      Identifier(identPath) {
+        const name = identPath.node.name;
+        const inlineCand = inlineCandidates.get(name);
+        if (inlineCand && !identPath.isBindingIdentifier()) {
+          inlineCand.usageCount++;
+        }
+      },
+    });
+  }
+
+  private applyInlineAndFold(ast: t.File): void {
+    const constants = this.collectConstants(ast);
+    const inlineCandidates = this.collectInlineCandidates(ast);
+    this.countInlineUsages(ast, inlineCandidates);
+    this.applyConstantAndInlineReplacement(ast, constants, inlineCandidates);
+    this.applyBinaryExpressionFolding(ast);
+    this.applyUnaryExpressionFolding(ast);
+  }
+
+  private applyConstantAndInlineReplacement(
+    ast: t.File,
+    constants: Map<string, t.Expression>,
+    inlineCandidates: Map<string, { value: t.Expression; usageCount: number }>,
+  ): void {
+    traverse(ast, {
+      Identifier(identPath) {
+        const ip = identPath as any;
+        if (ip.isBindingIdentifier?.()) return;
+        const parent = ip.parentPath;
+        if (!parent) return;
+        if (parent.isObjectProperty?.({ key: ip.node })) return;
+        if (parent.isMemberExpression?.({ property: ip.node }) && !parent.node.computed) return;
+
+        const constVal = constants.get(ip.node.name);
+        if (constVal) {
+          ip.replaceWith(t.cloneNode(constVal));
+          return;
+        }
+
+        const cand = inlineCandidates.get(ip.node.name);
+        if (cand && cand.usageCount <= 3) {
+          ip.replaceWith(t.cloneNode(cand.value));
+        }
+      },
+    });
+  }
+
+  private applyBinaryExpressionFolding(ast: t.File): void {
+    traverse(ast, {
+      BinaryExpression(binPath) {
+        const { left, right, operator } = binPath.node;
+
+        if (t.isNumericLiteral(left) && t.isNumericLiteral(right)) {
+          let result: number | undefined;
           switch (operator) {
             case '+':
               result = left.value + right.value;
@@ -78,223 +231,239 @@ export class ASTOptimizer {
               result = left.value * right.value;
               break;
             case '/':
-              result = left.value / right.value;
+              if (right.value !== 0) result = left.value / right.value;
               break;
             case '%':
-              result = left.value % right.value;
+              if (right.value !== 0) result = left.value % right.value;
               break;
             case '**':
               result = left.value ** right.value;
               break;
-            default:
-              return;
+            case '|':
+              result = left.value | right.value;
+              break;
+            case '&':
+              result = left.value & right.value;
+              break;
+            case '^':
+              result = left.value ^ right.value;
+              break;
+            case '<<':
+              result = left.value << right.value;
+              break;
+            case '>>':
+              result = left.value >> right.value;
+              break;
+            case '>>>':
+              result = left.value >>> right.value;
+              break;
           }
-
-          path.replaceWith(t.numericLiteral(result));
+          if (result !== undefined && Number.isFinite(result)) {
+            binPath.replaceWith(t.numericLiteral(result));
+            return;
+          }
         }
 
         if (t.isStringLiteral(left) && t.isStringLiteral(right) && operator === '+') {
-          path.replaceWith(t.stringLiteral(left.value + right.value));
+          binPath.replaceWith(t.stringLiteral(left.value + right.value));
+          return;
         }
-      },
-
-      UnaryExpression(path) {
-        const { argument, operator } = path.node;
-
-        if (t.isNumericLiteral(argument)) {
-          if (operator === '-') {
-            path.replaceWith(t.numericLiteral(-argument.value));
-          } else if (operator === '+') {
-            path.replaceWith(t.numericLiteral(argument.value));
-          } else if (operator === '!') {
-            path.replaceWith(t.booleanLiteral(!argument.value));
-          }
+        if (t.isStringLiteral(left) && t.isNumericLiteral(right) && operator === '+') {
+          binPath.replaceWith(t.stringLiteral(left.value + String(right.value)));
+          return;
         }
-
-        if (t.isBooleanLiteral(argument) && operator === '!') {
-          path.replaceWith(t.booleanLiteral(!argument.value));
-        }
-      },
-    });
-  }
-
-  private constantPropagation(ast: t.File): void {
-    const constants = new Map<string, t.Expression>();
-
-    traverse(ast, {
-      VariableDeclarator(path) {
-        const { id, init } = path.node;
-
-        if (t.isIdentifier(id) && init && t.isLiteral(init)) {
-          constants.set(id.name, init);
-        }
-      },
-
-      enter(path) {
-        if (!path.isIdentifier()) {
+        if (t.isNumericLiteral(left) && t.isStringLiteral(right) && operator === '+') {
+          binPath.replaceWith(t.stringLiteral(String(left.value) + right.value));
           return;
         }
 
-        const name = path.node.name;
-        const constant = constants.get(name);
-        const isBindingIdentifier = path.isBindingIdentifier();
-
-        if (constant && !isBindingIdentifier) {
-          (path as unknown as NodePath<t.Node>).replaceWith(t.cloneNode(constant));
+        if (
+          (operator === '+' && t.isNumericLiteral(right) && right.value === 0) ||
+          (operator === '-' && t.isNumericLiteral(right) && right.value === 0) ||
+          (operator === '*' && t.isNumericLiteral(right) && right.value === 1) ||
+          (operator === '/' && t.isNumericLiteral(right) && right.value === 1) ||
+          (operator === '**' && t.isNumericLiteral(right) && right.value === 1)
+        ) {
+          binPath.replaceWith(left);
+          return;
+        }
+        if (
+          (operator === '*' && t.isNumericLiteral(right) && right.value === 0) ||
+          (operator === '**' && t.isNumericLiteral(right) && right.value === 0)
+        ) {
+          binPath.replaceWith(t.numericLiteral(operator === '**' ? 1 : 0));
+          return;
+        }
+        if (
+          (operator === '===' || operator === '==') &&
+          t.isIdentifier(left) &&
+          t.isIdentifier(right) &&
+          left.name === right.name
+        ) {
+          binPath.replaceWith(t.booleanLiteral(true));
+          return;
+        }
+        if (
+          (operator === '!==' || operator === '!=') &&
+          t.isIdentifier(left) &&
+          t.isIdentifier(right) &&
+          left.name === right.name
+        ) {
+          binPath.replaceWith(t.booleanLiteral(false));
+          return;
         }
       },
     });
   }
 
-  private deadCodeElimination(ast: t.File): void {
+  private applyUnaryExpressionFolding(ast: t.File): void {
     traverse(ast, {
-      IfStatement(path) {
-        const { test, consequent, alternate } = path.node;
+      UnaryExpression(unPath) {
+        const { argument, operator } = unPath.node;
+        if (operator === '!' && t.isUnaryExpression(argument) && argument.operator === '!') {
+          unPath.replaceWith(t.callExpression(t.identifier('Boolean'), [argument.argument]));
+        }
+      },
+    });
+  }
+
+  private passControlFlowAndStatements(ast: t.File): void {
+    traverse(ast, {
+      IfStatement(ifPath) {
+        const { test, consequent, alternate } = ifPath.node;
 
         if (t.isBooleanLiteral(test)) {
-          if (test.value) {
-            path.replaceWith(consequent);
-          } else {
-            if (alternate) {
-              path.replaceWith(alternate);
-            } else {
-              path.remove();
-            }
-          }
+          ifPath.replaceWith(test.value ? consequent : (alternate ?? t.emptyStatement()));
+          return;
+        }
+        if (t.isNumericLiteral(test)) {
+          ifPath.replaceWith(test.value !== 0 ? consequent : (alternate ?? t.emptyStatement()));
         }
       },
 
-      ConditionalExpression(path) {
-        const { test, consequent, alternate } = path.node;
-
+      ConditionalExpression(condPath) {
+        const { test, consequent, alternate } = condPath.node;
         if (t.isBooleanLiteral(test)) {
-          path.replaceWith(test.value ? consequent : alternate);
+          condPath.replaceWith(test.value ? consequent : alternate);
+          return;
+        }
+        if (t.isNumericLiteral(test)) {
+          condPath.replaceWith(test.value !== 0 ? consequent : alternate);
         }
       },
 
-      LogicalExpression(path) {
-        const { left, right, operator } = path.node;
+      LogicalExpression(logPath) {
+        const { left, right, operator } = logPath.node;
 
         if (t.isBooleanLiteral(left)) {
           if (operator === '&&') {
-            path.replaceWith(left.value ? right : left);
+            logPath.replaceWith(left.value ? right : left);
           } else if (operator === '||') {
-            path.replaceWith(left.value ? left : right);
+            logPath.replaceWith(left.value ? left : right);
           }
-        }
-      },
-    });
-  }
-
-  private expressionSimplification(ast: t.File): void {
-    traverse(ast, {
-      BinaryExpression(path) {
-        const { left, right, operator } = path.node;
-
-        if (operator === '+' && t.isNumericLiteral(right) && right.value === 0) {
-          path.replaceWith(left);
-        }
-
-        if (operator === '*' && t.isNumericLiteral(right) && right.value === 1) {
-          path.replaceWith(left);
-        }
-
-        if (operator === '*' && t.isNumericLiteral(right) && right.value === 0) {
-          path.replaceWith(t.numericLiteral(0));
-        }
-      },
-
-      UnaryExpression(path) {
-        const { argument, operator } = path.node;
-
-        if (operator === '!' && t.isUnaryExpression(argument) && argument.operator === '!') {
-          path.replaceWith(t.callExpression(t.identifier('Boolean'), [argument.argument]));
-        }
-      },
-    });
-  }
-
-  private variableInlining(ast: t.File): void {
-    const inlineCandidates = new Map<string, { value: t.Expression; usageCount: number }>();
-
-    traverse(ast, {
-      VariableDeclarator(path) {
-        const { id, init } = path.node;
-
-        if (t.isIdentifier(id) && init && t.isLiteral(init)) {
-          inlineCandidates.set(id.name, { value: init, usageCount: 0 });
-        }
-      },
-
-      Identifier(path) {
-        const name = path.node.name;
-        const candidate = inlineCandidates.get(name);
-
-        if (candidate && !path.isBindingIdentifier()) {
-          candidate.usageCount++;
-        }
-      },
-    });
-
-    traverse(ast, {
-      enter(path) {
-        if (!path.isIdentifier()) {
           return;
         }
 
-        const name = path.node.name;
-        const candidate = inlineCandidates.get(name);
-        const isBindingIdentifier = path.isBindingIdentifier();
+        if (t.isNumericLiteral(left)) {
+          if (operator === '&&') {
+            logPath.replaceWith(left.value !== 0 ? right : t.numericLiteral(0));
+          } else if (operator === '||') {
+            logPath.replaceWith(left.value !== 0 ? left : right);
+          }
+        }
+      },
 
-        if (candidate && candidate.usageCount <= 3 && !isBindingIdentifier) {
-          (path as unknown as NodePath<t.Node>).replaceWith(t.cloneNode(candidate.value));
+      ExpressionStatement(exprStmtPath) {
+        const expr = exprStmtPath.node.expression;
+
+        const isIIFE = (node: t.Expression): node is t.CallExpression => {
+          if (!t.isCallExpression(node)) return false;
+          const callee = node.callee;
+          return (
+            (t.isFunctionExpression(callee) || t.isArrowFunctionExpression(callee)) &&
+            node.arguments.length === 0
+          );
+        };
+
+        if (!isIIFE(expr)) return;
+
+        const callee = expr.callee as t.FunctionExpression | t.ArrowFunctionExpression;
+        if (callee.params.length > 0) return;
+
+        let body: t.Statement[];
+        if (t.isBlockStatement(callee.body)) {
+          body = callee.body.body;
+        } else {
+          body = [t.expressionStatement(callee.body as t.Expression)];
+        }
+
+        if (body.some((s) => t.isReturnStatement(s))) return;
+        if (body.some((s) => t.isThrowStatement(s))) return;
+        if (body.some((s) => t.isVariableDeclaration(s) && s.kind !== 'var')) return;
+
+        if (body.length > 0) {
+          exprStmtPath.replaceWithMultiple(body);
+        } else {
+          exprStmtPath.remove();
         }
       },
     });
   }
 
-  private objectPropertyUnfolding(ast: t.File): void {
+  private passObjectAndSequenceOps(ast: t.File): void {
     traverse(ast, {
-      MemberExpression(path) {
-        const { object, property, computed } = path.node;
-
+      MemberExpression(memPath) {
+        const { object, property, computed } = memPath.node;
         if (computed && t.isStringLiteral(property)) {
           if (/^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(property.value)) {
-            path.replaceWith(t.memberExpression(object, t.identifier(property.value), false));
+            memPath.replaceWith(t.memberExpression(object, t.identifier(property.value), false));
           }
         }
       },
-    });
-  }
 
-  private computedPropertyResolution(ast: t.File): void {
-    traverse(ast, {
-      ObjectProperty(path) {
-        const { key, computed } = path.node;
-
+      ObjectProperty(objPropPath) {
+        const { key, computed } = objPropPath.node;
         if (computed && t.isStringLiteral(key)) {
           if (/^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(key.value)) {
-            path.node.computed = false;
-            path.node.key = t.identifier(key.value);
+            objPropPath.node.computed = false;
+            objPropPath.node.key = t.identifier(key.value);
           }
         }
       },
-    });
-  }
 
-  private sequenceExpressionExpansion(ast: t.File): void {
-    traverse(ast, {
-      SequenceExpression(path: NodePath<t.SequenceExpression>) {
-        const { expressions } = path.node;
-
+      SequenceExpression(seqPath) {
+        const { expressions } = seqPath.node;
         if (expressions.length === 1 && expressions[0]) {
-          path.replaceWith(expressions[0]);
+          seqPath.replaceWith(expressions[0]);
+          return;
         }
+        if (seqPath.parentPath?.isExpressionStatement()) {
+          const stmts = expressions.map((expr: t.Expression) => t.expressionStatement(expr));
+          seqPath.parentPath.replaceWithMultiple(stmts);
+        }
+      },
 
-        if (path.parentPath.isExpressionStatement()) {
-          const statements = expressions.map((expr: t.Expression) => t.expressionStatement(expr));
-          path.parentPath.replaceWithMultiple(statements);
-        }
+      'BinaryExpression|UnaryExpression': {
+        exit(bPath) {
+          const node = bPath.node as t.BinaryExpression;
+          if (node.operator !== '+') return;
+
+          const collectParts = (expr: t.Expression): string | null => {
+            if (t.isStringLiteral(expr)) return expr.value;
+            if (t.isNumericLiteral(expr)) return String(expr.value);
+            if (t.isBinaryExpression(expr) && expr.operator === '+') {
+              const l = collectParts(expr.left as t.Expression);
+              const r = collectParts(expr.right as t.Expression);
+              if (l !== null && r !== null) return l + r;
+            }
+            return null;
+          };
+
+          const result = collectParts(node);
+          if (result !== null) {
+            bPath.replaceWith(t.stringLiteral(result));
+          }
+        },
       },
     });
   }

--- a/src/modules/deobfuscator/AdvancedDeobfuscator.ast.ts
+++ b/src/modules/deobfuscator/AdvancedDeobfuscator.ast.ts
@@ -4,6 +4,73 @@ import traverse, { type NodePath } from '@babel/traverse';
 import * as t from '@babel/types';
 import { logger } from '@utils/logger';
 
+export function decodeEscapeSequences(code: string): string {
+  logger.info('Decoding escape sequences (hex/unicode)...');
+
+  let result = code;
+  let changed = false;
+
+  const hexDecoded = result.replace(/\\x([0-9a-fA-F]{2})/g, (_m, hex) => {
+    changed = true;
+    return String.fromCharCode(parseInt(hex, 16));
+  });
+  if (hexDecoded !== result) result = hexDecoded;
+
+  const unicodeDecoded = result.replace(/\\u([0-9a-fA-F]{4})/g, (_m, hex) => {
+    changed = true;
+    return String.fromCharCode(parseInt(hex, 16));
+  });
+  if (unicodeDecoded !== result) result = unicodeDecoded;
+
+  if (changed) {
+    logger.info('Escape sequences decoded');
+  }
+  return result;
+}
+
+export function normalizeInvisibleUnicode(code: string): string {
+  const INVISIBLE_RE = /[\u200b-\u200f\u202a-\u202e\ufeff\u2060-\u2064\u00ad]/g;
+  if (!INVISIBLE_RE.test(code)) return code;
+  logger.info('Stripping invisible Unicode characters...');
+  const cleaned = code.replace(INVISIBLE_RE, '');
+  logger.info('Invisible Unicode removed');
+  return cleaned;
+}
+
+export function inlineUnescapeAtob(code: string): string {
+  logger.info('Decoding inline unescape/atob calls...');
+
+  let result = code;
+  let changed = false;
+
+  result = result.replace(
+    /unescape\s*\(\s*["'`]((?:%[0-9a-fA-F]{2})+)["'`]\s*\)/g,
+    (_m, encoded) => {
+      try {
+        changed = true;
+        return JSON.stringify(decodeURIComponent(encoded));
+      } catch {
+        return _m;
+      }
+    },
+  );
+
+  result = result.replace(/atob\s*\(\s*["'`]([A-Za-z0-9+/\s]+=*)["'`]\s*\)/g, (_m, b64) => {
+    try {
+      const decoded = Buffer.from(b64.replace(/\s/g, ''), 'base64').toString('utf8');
+      changed = true;
+      return JSON.stringify(decoded);
+    } catch {
+      return _m;
+    }
+  });
+
+  if (changed) {
+    logger.info('Inline unescape/atob decoded');
+  }
+  return result;
+}
+
 export function derotateStringArray(code: string): string {
   logger.info('Derotating string array...');
 
@@ -12,6 +79,9 @@ export function derotateStringArray(code: string): string {
       sourceType: 'module',
       plugins: ['jsx', 'typescript'],
     });
+    if (!ast) {
+      throw new Error('Failed to parse code into AST');
+    }
 
     let derotated = 0;
 
@@ -49,8 +119,16 @@ export function derotateStringArray(code: string): string {
 
     return code;
   } catch (error) {
-    logger.error('Failed to derotate string array:', error);
-    return code;
+    const errorDetails = {
+      error: 'StringArrayDerotationFailed',
+      message: error instanceof Error ? error.message : 'Unknown error',
+      timestamp: new Date().toISOString(),
+      context: {
+        codePreview: code.substring(0, 500),
+      },
+    };
+    logger.error(`String array derotation failed: ${JSON.stringify(errorDetails)}`);
+    throw new Error(JSON.stringify(errorDetails));
   }
 }
 

--- a/src/modules/deobfuscator/DeobfuscationConfig.ts
+++ b/src/modules/deobfuscator/DeobfuscationConfig.ts
@@ -1,0 +1,80 @@
+/**
+ * Configuration constants for JSHook MCP deobfuscator
+ * Centralized configuration to avoid magic numbers
+ */
+
+export const DEOBFUSCATION_CONFIG = {
+  // Input validation
+  MAX_INPUT_SIZE_BYTES: 5 * 1024 * 1024, // 5MB
+  MAX_PATTERN_MATCHES: 100,
+  PATTERN_TIMEOUT_MS: 1000,
+
+  // API configuration
+  PRO_API_TIMEOUT_MS: 300000, // 5 minutes
+  MIN_API_TOKEN_LENGTH: 10,
+
+  // Performance limits
+  MAX_ITERATIONS: 50,
+  MAX_BUNDLE_MODULES: 100,
+  CACHE_TTL_SECONDS: 30,
+  CACHE_MAX_ENTRIES: 100,
+
+  // Security limits
+  MAX_IDENTIFIER_LENGTH: 100,
+  MAX_MATCHES_PER_PATTERN: 50,
+} as const;
+
+// Pattern compilation cache to avoid recompilation
+export const COMPILED_PATTERNS = {
+  OBFUSCATOR_IO_STRING_ARRAY: /\.split\(['"]([^'"]+)['"]\)/,
+  OBFUSCATOR_IO_VAR: /(?:var|function|const)\s+_0x[a-f0-9]{4,}\b/g,
+  UNICODE_ESCAPE: /(?:\\u[0-9a-fA-F]{4}){4,}/,
+  JSFUCK: /^\s*[\[\]()+!]{20,}\s*$/m,
+} as const;
+
+// Cache for regex patterns
+export const REGEX_CACHE = new Map<string, RegExp>();
+
+/**
+ * Get cached regex pattern or create and cache new one
+ */
+export function getCachedPattern(pattern: string): RegExp {
+  if (!REGEX_CACHE.has(pattern)) {
+    REGEX_CACHE.set(pattern, new RegExp(pattern));
+  }
+  return REGEX_CACHE.get(pattern)!;
+}
+
+/**
+ * Validate input size before processing
+ */
+export function validateInputSize(
+  code: string,
+  maxSize: number = DEOBFUSCATION_CONFIG.MAX_INPUT_SIZE_BYTES,
+): void {
+  if (code.length > maxSize) {
+    throw new Error(`Input code too large: ${code.length} bytes (max: ${maxSize})`);
+  }
+}
+
+/**
+ * Create a timeout wrapper for async operations
+ */
+export async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  errorMessage: string = 'Operation timed out',
+): Promise<T> {
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    setTimeout(() => reject(new Error(errorMessage)), timeoutMs);
+  });
+
+  return Promise.race([promise, timeoutPromise]);
+}
+
+/**
+ * Escape regex special characters for safe pattern building
+ */
+export function escapeRegExp(string: string): string {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/src/modules/deobfuscator/DeobfuscationPipeline.ts
+++ b/src/modules/deobfuscator/DeobfuscationPipeline.ts
@@ -1,0 +1,214 @@
+import { logger } from '@utils/logger';
+import {
+  detectObfuscationType,
+  calculateReadabilityScore,
+} from '@modules/deobfuscator/Deobfuscator.utils';
+import { runWebcrack } from '@modules/deobfuscator/webcrack';
+import { ASTOptimizer } from '@modules/deobfuscator/ASTOptimizer';
+import { UniversalUnpacker } from '@modules/deobfuscator/PackerDeobfuscator';
+import {
+  decodeEscapeSequences,
+  normalizeInvisibleUnicode,
+  inlineUnescapeAtob,
+  derotateStringArray,
+  removeDeadCode,
+  removeOpaquePredicates,
+  decodeStrings,
+  applyASTOptimizations,
+} from '@modules/deobfuscator/AdvancedDeobfuscator.ast';
+import type { ObfuscationType } from '@internal-types/deobfuscator';
+
+export interface PipelineOptions {
+  code: string;
+  unpack?: boolean;
+  unminify?: boolean;
+  jsx?: boolean;
+  mangle?: boolean;
+  timeout?: number;
+  outputDir?: string;
+  forceOutput?: boolean;
+  includeModuleCode?: boolean;
+  maxBundleModules?: number;
+  skipWebcrack?: boolean;
+  skipAST?: boolean;
+}
+
+export interface PipelineStepResult {
+  stage: string;
+  applied: boolean;
+  codeLength: number;
+  readabilityDelta: number;
+  warnings?: string[];
+}
+
+export interface PipelineResult {
+  code: string;
+  originalCode: string;
+  readabilityScore: number;
+  readabilityScoreBefore: number;
+  confidence: number;
+  obfuscationTypes: ObfuscationType[];
+  steps: PipelineStepResult[];
+  warnings: string[];
+}
+
+export class DeobfuscationPipeline {
+  private readonly astOptimizer = new ASTOptimizer();
+  private readonly universalUnpacker = new UniversalUnpacker();
+
+  async run(options: PipelineOptions): Promise<PipelineResult> {
+    const startTime = Date.now();
+    const originalCode = options.code;
+    const obfuscationTypes = detectObfuscationType(originalCode);
+    const scoreBefore = calculateReadabilityScore(originalCode);
+    const warnings: string[] = [];
+    const steps: PipelineStepResult[] = [];
+
+    logger.info(`DeobfuscationPipeline: detected [${obfuscationTypes.join(', ')}]`);
+
+    let current = originalCode;
+
+    current = this.runStep(steps, warnings, 'invisible-unicode', current, () =>
+      normalizeInvisibleUnicode(current),
+    );
+
+    current = this.runStep(steps, warnings, 'escape-sequences', current, () =>
+      decodeEscapeSequences(current),
+    );
+
+    current = this.runStep(steps, warnings, 'inline-unescape-atob', current, () =>
+      inlineUnescapeAtob(current),
+    );
+
+    const unpackResult = await this.universalUnpacker.deobfuscate(current);
+    const beforeUnpack = current;
+    if (unpackResult.success) {
+      current = unpackResult.code;
+      steps.push({
+        stage: `universal-unpack:${unpackResult.type}`,
+        applied: true,
+        codeLength: current.length,
+        readabilityDelta:
+          calculateReadabilityScore(current) - calculateReadabilityScore(beforeUnpack),
+      });
+    }
+
+    if (options.skipWebcrack !== true) {
+      try {
+        const webcrackResult = await Promise.race([
+          runWebcrack(current, {
+            unpack: options.unpack ?? true,
+            unminify: options.unminify ?? true,
+            jsx: options.jsx ?? true,
+            mangle: options.mangle ?? false,
+            outputDir: options.outputDir,
+            forceOutput: options.forceOutput,
+            includeModuleCode: options.includeModuleCode,
+            maxBundleModules: options.maxBundleModules,
+          }),
+          new Promise<never>((_, reject) =>
+            setTimeout(() => reject(new Error('webcrack timeout')), options.timeout ?? 30_000),
+          ),
+        ]);
+
+        if (webcrackResult.applied && webcrackResult.code) {
+          const beforeWC = current;
+          current = webcrackResult.code;
+          steps.push({
+            stage: 'webcrack',
+            applied: true,
+            codeLength: current.length,
+            readabilityDelta:
+              calculateReadabilityScore(current) - calculateReadabilityScore(beforeWC),
+          });
+        } else {
+          steps.push({
+            stage: 'webcrack',
+            applied: false,
+            codeLength: current.length,
+            readabilityDelta: 0,
+          });
+          if (webcrackResult.reason) warnings.push(`webcrack skipped: ${webcrackResult.reason}`);
+        }
+      } catch (e) {
+        warnings.push(`webcrack error: ${e instanceof Error ? e.message : String(e)}`);
+        steps.push({
+          stage: 'webcrack',
+          applied: false,
+          codeLength: current.length,
+          readabilityDelta: 0,
+        });
+      }
+    }
+
+    if (options.skipAST !== true) {
+      current = this.runStep(steps, warnings, 'derotate-string-array', current, () =>
+        derotateStringArray(current),
+      );
+
+      current = this.runStep(steps, warnings, 'decode-strings', current, () =>
+        decodeStrings(current),
+      );
+
+      current = this.runStep(steps, warnings, 'remove-dead-code', current, () =>
+        removeDeadCode(current),
+      );
+
+      current = this.runStep(steps, warnings, 'remove-opaque-predicates', current, () =>
+        removeOpaquePredicates(current),
+      );
+
+      current = this.runStep(steps, warnings, 'ast-optimizations', current, () =>
+        applyASTOptimizations(current),
+      );
+
+      current = this.runStep(steps, warnings, 'ast-optimizer', current, () =>
+        this.astOptimizer.optimize(current),
+      );
+    }
+
+    const scoreAfter = calculateReadabilityScore(current);
+    const appliedCount = steps.filter((s) => s.applied).length;
+    const confidence = Math.min(0.5 + scoreAfter / 200 + appliedCount * 0.04, 0.99);
+
+    logger.info(
+      `DeobfuscationPipeline complete in ${Date.now() - startTime}ms, readability ${scoreBefore} → ${scoreAfter}, confidence ${(confidence * 100).toFixed(1)}%`,
+    );
+
+    return {
+      code: current,
+      originalCode,
+      readabilityScore: scoreAfter,
+      readabilityScoreBefore: scoreBefore,
+      confidence,
+      obfuscationTypes,
+      steps,
+      warnings,
+    };
+  }
+
+  private runStep(
+    steps: PipelineStepResult[],
+    warnings: string[],
+    stage: string,
+    current: string,
+    fn: () => string,
+  ): string {
+    const scoreBefore = calculateReadabilityScore(current);
+    try {
+      const next = fn();
+      const scoreAfter = calculateReadabilityScore(next);
+      steps.push({
+        stage,
+        applied: next !== current,
+        codeLength: next.length,
+        readabilityDelta: scoreAfter - scoreBefore,
+      });
+      return next;
+    } catch (e) {
+      warnings.push(`${stage} failed: ${e instanceof Error ? e.message : String(e)}`);
+      steps.push({ stage, applied: false, codeLength: current.length, readabilityDelta: 0 });
+      return current;
+    }
+  }
+}

--- a/src/modules/deobfuscator/Deobfuscator.ts
+++ b/src/modules/deobfuscator/Deobfuscator.ts
@@ -1,4 +1,5 @@
 import crypto from 'crypto';
+import { z } from 'zod';
 import type { DeobfuscateOptions, DeobfuscateResult, ObfuscationType } from '@internal-types/index';
 import { logger } from '@utils/logger';
 
@@ -7,6 +8,42 @@ import {
   detectObfuscationType as detectObfuscationTypeUtil,
 } from '@modules/deobfuscator/Deobfuscator.utils';
 import { runWebcrack } from '@modules/deobfuscator/webcrack';
+import { deobfuscateWithProApi } from '@modules/deobfuscator/ProApiClient';
+
+// Pro API token validation
+const MIN_API_TOKEN_LENGTH = 10;
+
+// Input validation schema
+const DeobfuscateOptionsSchema = z.object({
+  code: z.string().min(1, 'Code must not be empty'),
+  aggressive: z.boolean().optional(),
+  unpack: z.boolean().default(true),
+  unminify: z.boolean().default(true),
+  jsx: z.boolean().default(false),
+  mangle: z.boolean().default(false),
+  renameVariables: z.boolean().optional(),
+  includeModuleCode: z.boolean().default(false),
+  maxBundleModules: z.number().int().positive().default(100),
+  outputDir: z.string().optional(),
+  forceOutput: z.boolean().default(false),
+  preserveLogic: z.boolean().optional(),
+  inlineFunctions: z.boolean().optional(),
+  proApiToken: z
+    .string()
+    .min(MIN_API_TOKEN_LENGTH, `API token must be at least ${MIN_API_TOKEN_LENGTH} characters`)
+    .optional(),
+  proApiVersion: z.string().optional(),
+  mappings: z
+    .array(
+      z.object({
+        path: z.string(),
+        pattern: z.string(),
+        matchType: z.enum(['includes', 'regex', 'exact']).optional(),
+        target: z.enum(['code', 'path']).optional(),
+      }),
+    )
+    .optional(),
+});
 
 export class Deobfuscator {
   private resultCache = new Map<string, DeobfuscateResult>();
@@ -37,7 +74,9 @@ export class Deobfuscator {
   }
 
   async deobfuscate(options: DeobfuscateOptions): Promise<DeobfuscateResult> {
-    const cacheKey = this.generateCacheKey(options);
+    // Validate input
+    const validatedOptions = DeobfuscateOptionsSchema.parse(options);
+    const cacheKey = this.generateCacheKey(validatedOptions);
     const cached = this.resultCache.get(cacheKey);
     if (cached) {
       logger.debug('Deobfuscation result from cache');
@@ -45,10 +84,28 @@ export class Deobfuscator {
       return cached;
     }
 
+    // Check for Pro API token and use if available
+    const proApiToken =
+      (validatedOptions as any).proApiToken || process.env.OBFUSCATOR_IO_API_TOKEN;
+    const hasProFeatures =
+      (validatedOptions as any).vmObfuscation === true ||
+      (validatedOptions as any).parseHtml === true ||
+      (proApiToken && proApiToken.length > 0);
+
+    if (hasProFeatures && proApiToken && proApiToken.length > 0) {
+      const proResult = await deobfuscateWithProApi(validatedOptions);
+      if (proResult) {
+        logger.success('Pro API deobfuscation completed successfully');
+        return proResult;
+      } else {
+        logger.warn('Pro API usage requested but failed, falling back to webcrack');
+      }
+    }
+
     logger.info('Starting webcrack deobfuscation...');
     const startTime = Date.now();
 
-    const obfuscationType = this.detectObfuscationType(options.code);
+    const obfuscationType = this.detectObfuscationType(validatedOptions.code);
     const warnings: string[] = [];
 
     if (options.aggressive !== undefined) {
@@ -63,22 +120,51 @@ export class Deobfuscator {
       warnings.push('inlineFunctions is deprecated and ignored.');
     }
 
-    const webcrackResult = await runWebcrack(options.code, {
-      unpack: options.unpack,
-      unminify: options.unminify,
-      jsx: options.jsx,
-      mangle: options.mangle ?? options.renameVariables,
-      mappings: options.mappings,
-      includeModuleCode: options.includeModuleCode,
-      maxBundleModules: options.maxBundleModules,
-      outputDir: options.outputDir,
-      forceOutput: options.forceOutput,
-    });
+    const webcrackInvocationOptions = {
+      unpack: validatedOptions.unpack,
+      unminify: validatedOptions.unminify,
+      jsx: validatedOptions.jsx,
+      mangle: validatedOptions.mangle ?? validatedOptions.renameVariables,
+      mappings: validatedOptions.mappings as any,
+      includeModuleCode: validatedOptions.includeModuleCode,
+      maxBundleModules: validatedOptions.maxBundleModules,
+      outputDir: validatedOptions.outputDir,
+      forceOutput: validatedOptions.forceOutput,
+    };
 
-    if (!webcrackResult.applied) {
-      const reason = webcrackResult.reason ?? 'webcrack did not return a result';
-      logger.error(`webcrack deobfuscation failed: ${reason}`);
-      throw new Error(reason);
+    const webcrackResultInternal = await Promise.race([
+      runWebcrack(validatedOptions.code, webcrackInvocationOptions),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('webcrack timeout after 30 seconds')), 30_000),
+      ).catch((err) => {
+        logger.warn(`webcrack timeout: ${err instanceof Error ? err.message : String(err)}`);
+        return { applied: false, reason: 'timeout' } as Awaited<ReturnType<typeof runWebcrack>>;
+      }),
+    ]);
+
+    const webcrackResult = webcrackResultInternal;
+
+    if (!webcrackResultInternal.applied) {
+      const reason = webcrackResultInternal.reason ?? 'webcrack did not return a result';
+      // Fallback to cached result if available
+      if (this.resultCache.has(cacheKey)) {
+        logger.warn(`webcrack failed (${reason}), falling back to cached result`);
+        const cachedResult = this.resultCache.get(cacheKey)!;
+        cachedResult.warnings = [`webcrack failed: ${reason}`];
+        return cachedResult;
+      }
+
+      const errorDetails = {
+        error: 'DeobfuscationFailed',
+        reason,
+        timestamp: new Date().toISOString(),
+        context: {
+          optionsUsed: webcrackResultInternal.optionsUsed,
+          codePreview: validatedOptions.code.substring(0, 500),
+        },
+      };
+      logger.error(`webcrack deobfuscation failed: ${JSON.stringify(errorDetails)}`);
+      throw new Error(JSON.stringify(errorDetails));
     }
 
     const analysis = this.buildAnalysis(webcrackResult, obfuscationType);

--- a/src/modules/deobfuscator/Deobfuscator.utils.ts
+++ b/src/modules/deobfuscator/Deobfuscator.utils.ts
@@ -1,44 +1,181 @@
 import type { ObfuscationType } from '@internal-types/index';
 
-export function detectObfuscationType(code: string): ObfuscationType[] {
-  const types: ObfuscationType[] = [];
+const HEX_HEAVY_RE = /(?:\\x[0-9a-fA-F]{2}){6,}/;
+const HEX_LITERALS_RE = /\b0x[0-9a-fA-F]{3,}\b/g;
+const UNICODE_ESCAPE_RE = /(?:\\u[0-9a-fA-F]{4}){4,}/;
+const JSFUCK_RE = /^\s*[\[\]()+!]{20,}\s*$/m;
+const AAENCODE_RE = /ﾟωﾟ|ﾟΘﾟ|ﾟｰﾟ|ﾟ-ﾟ/;
+const JJENCODE_RE = /\$=~\[\]|_\$\[/;
+const PACKER_RE = /eval\s*\(\s*function\s*\(\s*p\s*,\s*a\s*,\s*c\s*,\s*k\s*,\s*e\s*,\s*[dr]\s*\)/;
+const EVAL_FN_RE = /eval\s*\(\s*(unescape|atob|decodeURIComponent)\s*\(/;
+const SELF_MOD_RE = /document\.write\s*\(\s*unescape|eval\s*\(.*?eval/s;
+const INVISIBLE_UNICODE_RE = /[\u200b-\u200f\u202a-\u202e\ufeff\u2060-\u2064]/;
+const CFF_RE = /while\s*\(\s*true\s*\)\s*\{[\s\S]{0,200}switch\s*\(/i;
+const STRING_ARRAY_ROTATION_RE =
+  /\(\s*function\s*\(\s*\w+\s*,\s*\w+\s*\)\s*\{[\s\S]{0,400}\.push\s*\(\s*\w+\.shift\s*\(\s*\)\s*\)/;
+const DEAD_CODE_RE = /if\s*\(\s*(true|false|0x[0-9]+\s*[><=!]+\s*0x[0-9]+)\s*\)/g;
+const OPAQUE_PREDICATE_RE = /if\s*\(\s*[\w$]+\s*\(\s*\)\s*\)\s*\{[\s\S]{0,100}\}/;
+const WEBPACK_RE = /__webpack_require__|webpackJsonp|__webpack_exports__|webpack_module/;
+const BROWSERIFY_RE = /require\s*=\s*function\s*\w*\s*\(\s*t\s*\)|\/\*\s*browserify\s*\*\//i;
+const ROLLUP_VITE_RE = /__vitePreload|__rollup_|\/\*\s*@vite\b/;
+const OBFUSCATOR_IO_RE = /_0x[0-9a-f]{4,}\s*\[|var\s+_0x[0-9a-f]+\s*=/i;
+const JSDECODE_RE = /\x01|\x02|_(0x[a-f0-9]+)\s*=\s*\[/;
+const SCRAMBLER_RE = /\$⁠|‌|‍|‎|‏/;
+const HIDDEN_PROP_RE =
+  /Object\.defineProperty\s*\(\s*\w+\s*,\s*["'][\w$]+["']\s*,\s*\{[\s\S]*?hidden[\s\S]*?\}/i;
+const ENCODED_CALL_RE = /\[\s*(?:["'](?:[^"'\\]|\\.)*["']|\d+)\s*\]\s*\([^)]*\)/;
+const PROXY_OBF_RE = /Proxy\s*\(\s*(?:new\s+Function|\(function)/;
+const WITH_OBF_RE = /with\s*\(\s*\{[\s\S]*?\}/;
 
-  if (code.includes('_0x') || code.includes('\\x') || /var\s+_0x[a-f0-9]+\s*=/.test(code)) {
-    types.push('javascript-obfuscator');
+export function detectObfuscationType(code: string): ObfuscationType[] {
+  const types = new Set<ObfuscationType>();
+
+  if (OBFUSCATOR_IO_RE.test(code)) {
+    types.add('javascript-obfuscator');
   }
 
-  if (code.includes('__webpack_require__') || code.includes('webpackJsonp')) {
-    types.push('webpack');
+  if (WEBPACK_RE.test(code)) {
+    types.add('webpack');
+  }
+
+  if (BROWSERIFY_RE.test(code)) {
+    types.add('unknown');
+  }
+
+  if (ROLLUP_VITE_RE.test(code)) {
+    types.add('unknown');
   }
 
   if (code.length > 1000 && !code.includes('\n')) {
-    types.push('uglify');
+    types.add('uglify');
+  }
+
+  if (PACKER_RE.test(code)) {
+    types.add('packer');
+  }
+
+  if (EVAL_FN_RE.test(code) || SELF_MOD_RE.test(code)) {
+    types.add('eval-obfuscation');
   }
 
   if (code.includes('eval') && code.includes('Function')) {
-    types.push('vm-protection');
+    types.add('vm-protection');
   }
 
-  if (types.length === 0) {
-    types.push('unknown');
+  if (CFF_RE.test(code)) {
+    types.add('control-flow-flattening');
   }
 
-  return types;
+  if (STRING_ARRAY_ROTATION_RE.test(code)) {
+    types.add('string-array-rotation');
+  }
+
+  const deadMatches = code.match(DEAD_CODE_RE);
+  if (deadMatches && deadMatches.length >= 3) {
+    types.add('dead-code-injection');
+  }
+
+  if (OPAQUE_PREDICATE_RE.test(code)) {
+    types.add('opaque-predicates');
+  }
+
+  if (JSFUCK_RE.test(code)) {
+    types.add('jsfuck');
+  }
+
+  if (AAENCODE_RE.test(code)) {
+    types.add('aaencode');
+  }
+
+  if (JJENCODE_RE.test(code)) {
+    types.add('jjencode');
+  }
+
+  if (INVISIBLE_UNICODE_RE.test(code)) {
+    types.add('invisible-unicode');
+  }
+
+  if (HEX_HEAVY_RE.test(code)) {
+    types.add('hex-encoding');
+  }
+
+  if (UNICODE_ESCAPE_RE.test(code)) {
+    types.add('hex-encoding');
+  }
+
+  const base64Candidates = code.match(/["'`]([A-Za-z0-9+/]{40,}={0,2})["'`]/g);
+  if (base64Candidates && base64Candidates.length >= 2) {
+    types.add('base64-encoding');
+  }
+
+  const hexLiterals = code.match(HEX_LITERALS_RE);
+  if (hexLiterals && hexLiterals.length >= 10) {
+    types.add('hex-encoding');
+  }
+
+  if (JSDECODE_RE.test(code)) {
+    types.add('jsdecode');
+  }
+
+  if (SCRAMBLER_RE.test(code)) {
+    types.add('jscrambler');
+  }
+
+  if (HIDDEN_PROP_RE.test(code)) {
+    types.add('hidden-properties');
+  }
+
+  if (ENCODED_CALL_RE.test(code)) {
+    types.add('encoded-calls');
+  }
+
+  if (PROXY_OBF_RE.test(code)) {
+    types.add('proxy-obfuscation');
+  }
+
+  if (WITH_OBF_RE.test(code)) {
+    types.add('with-obfuscation');
+  }
+
+  if (types.size === 0) {
+    types.add('unknown');
+  }
+
+  return Array.from(types);
 }
 
 export function calculateReadabilityScore(code: string): number {
   let score = 0;
 
-  if (code.includes('\n')) score += 20;
+  if (code.includes('\n')) {
+    score += 15;
+    const lines = code.split('\n');
+    const nonEmptyLines = lines.filter((l) => l.trim().length > 0).length;
+    if (nonEmptyLines > 5) score += 5;
+  }
 
-  const varNames = code.match(/\b[a-zA-Z_$][a-zA-Z0-9_$]*\b/g) || [];
-  const avgLength = varNames.reduce((sum, name) => sum + name.length, 0) / (varNames.length || 1);
-  if (avgLength > 3) score += 30;
+  const identifiers = code.match(/\b[a-zA-Z_$][a-zA-Z0-9_$]*\b/g) ?? [];
+  const meaningfulCount = identifiers.filter((n) => n.length >= 4).length;
+  const ratio = identifiers.length > 0 ? meaningfulCount / identifiers.length : 0;
+  score += Math.round(ratio * 25);
 
-  const density = code.replace(/\s/g, '').length / code.length;
-  if (density < 0.8) score += 20;
+  const whitespaceRatio = (code.length - code.replace(/\s/g, '').length) / code.length;
+  if (whitespaceRatio >= 0.1) score += 10;
+  if (whitespaceRatio >= 0.2) score += 5;
 
-  if (!code.includes('_0x') && !code.includes('\\x')) score += 20;
+  if (!/_0x[0-9a-f]+/i.test(code)) score += 10;
+  if (!HEX_HEAVY_RE.test(code)) score += 5;
+  if (!UNICODE_ESCAPE_RE.test(code)) score += 5;
+  if (!JSFUCK_RE.test(code)) score += 5;
+
+  const commentMatches = code.match(/\/\/[^\n]*|\/\*[\s\S]*?\*\//g);
+  if (commentMatches && commentMatches.length > 0) score += 5;
+
+  const keywordCount = (
+    code.match(/\b(function|const|let|var|return|if|else|for|while|class|import|export)\b/g) ?? []
+  ).length;
+  const density = code.length > 0 ? keywordCount / (code.length / 100) : 0;
+  if (density >= 1) score += 5;
 
   return Math.min(score, 100);
 }

--- a/src/modules/deobfuscator/JSVMPDeobfuscator.restore.ts
+++ b/src/modules/deobfuscator/JSVMPDeobfuscator.restore.ts
@@ -46,16 +46,16 @@ async function restoreObfuscatorIO(
   let confidence = 0.5;
 
   try {
-    const stringArrayMatch = code.match(/var\s+(_0x[a-f0-9]+)\s*=\s*(\[.*?\]);/s);
+    const stringArrayMatch = code.match(/var\s+(_0x[a-f0-9]+)\s*=\s*(\[[\s\S]*?\]);/);
     if (stringArrayMatch) {
-      const arrayName = stringArrayMatch[1];
-      const arrayContent = stringArrayMatch[2];
+      const arrayName = stringArrayMatch[1] ?? '';
+      const arrayContent = stringArrayMatch[2] ?? '[]';
 
-      logger.info(` : ${arrayName}`);
+      logger.info(`Found string array: ${arrayName}`);
 
       try {
         const sandboxResult = await context.sandbox.execute({
-          code: `return ${arrayContent || '[]'};`,
+          code: `return ${arrayContent};`,
           timeoutMs: 3000,
         });
         const stringArray = sandboxResult.ok ? sandboxResult.output : undefined;
@@ -63,7 +63,7 @@ async function restoreObfuscatorIO(
         if (Array.isArray(stringArray)) {
           logger.info(`String array detected, ${stringArray.length} strings found`);
 
-          const refPattern = new RegExp(`${arrayName}\\[(\\d+)\\]`, 'g');
+          const refPattern = new RegExp(String.raw`${arrayName}\[(\d+)\]`, 'g');
           restored = restored.replace(refPattern, (_match, index) => {
             const idx = parseInt(index, 10);
             if (idx < stringArray.length) {
@@ -75,11 +75,11 @@ async function restoreObfuscatorIO(
           confidence += 0.2;
         }
       } catch (e) {
-        warnings.push(`: ${e}`);
+        warnings.push(`String array eval failed: ${e}`);
         unresolvedParts.push({
           location: 'String Array',
-          reason: '',
-          suggestion: '',
+          reason: 'Sandbox execution failed',
+          suggestion: 'Try running with a broader sandbox timeout',
         });
       }
     }
@@ -89,19 +89,21 @@ async function restoreObfuscatorIO(
       '',
     );
 
-    if (aggressive) {
-      restored = restored.replace(/\(function\s*\(\)\s*\{([\s\S]*)\}\(\)\);?/g, '$1');
-      confidence += 0.1;
-    }
-
-    restored = restored.replace(/0x([0-9a-f]+)/gi, (_match, hex) => {
-      return String(parseInt(hex, 16));
+    restored = restored.replace(/0x([0-9a-fA-F]+)/g, (_match, hex) => {
+      const val = parseInt(hex, 16);
+      return Number.isFinite(val) ? String(val) : _match;
     });
+
+    if (aggressive) {
+      restored = restored.replace(/\(function\s*\(\)\s*\{([\s\S]*?)\}\(\)\);?/g, '$1');
+      restored = restored.replace(/debugger;?/g, '');
+      confidence += 0.15;
+    }
 
     restored = restored.replace(/;\s*;/g, ';');
     restored = restored.replace(/\{\s*\}/g, '{}');
 
-    warnings.push('obfuscator.io detected, may need special handling');
+    warnings.push('obfuscator.io detected; string array replacement may be partial');
 
     return {
       code: restored,
@@ -110,7 +112,7 @@ async function restoreObfuscatorIO(
       unresolvedParts: unresolvedParts.length > 0 ? unresolvedParts : undefined,
     };
   } catch (error) {
-    warnings.push(`obfuscator.io: ${error}`);
+    warnings.push(`obfuscator.io restore error: ${error}`);
     return {
       code,
       confidence: 0.2,

--- a/src/modules/deobfuscator/JSVMPDeobfuscator.ts
+++ b/src/modules/deobfuscator/JSVMPDeobfuscator.ts
@@ -93,13 +93,17 @@ export class JSVMPDeobfuscator {
 
       return result;
     } catch (error) {
-      logger.error('JSVMP', error);
-      return {
-        isJSVMP: false,
-        deobfuscatedCode: code,
-        confidence: 0,
-        warnings: [`: ${error}`],
+      const errorDetails = {
+        error: 'JSVMPDeobfuscationFailed',
+        message: error instanceof Error ? error.message : 'Unknown error',
+        timestamp: new Date().toISOString(),
+        context: {
+          codePreview: code.substring(0, 500),
+          options,
+        },
       };
+      logger.error(`JSVMP deobfuscation failed: ${JSON.stringify(errorDetails)}`);
+      throw new Error(JSON.stringify(errorDetails));
     }
   }
 

--- a/src/modules/deobfuscator/JScramblerDeobfuscator.ts
+++ b/src/modules/deobfuscator/JScramblerDeobfuscator.ts
@@ -43,6 +43,9 @@ export class JScramberDeobfuscator {
         plugins: ['jsx', 'typescript'],
         errorRecovery: true,
       });
+      if (!ast) {
+        throw new Error('Failed to parse code into AST');
+      }
 
       if (this.detectSelfDefending(ast)) {
         this.removeSelfDefending(ast);
@@ -98,14 +101,17 @@ export class JScramberDeobfuscator {
         confidence,
       };
     } catch (error) {
-      logger.error('JScrambler', error);
-      return {
-        code: currentCode,
-        success: false,
-        transformations,
-        warnings: [...warnings, String(error)],
-        confidence: 0,
+      const errorDetails = {
+        error: 'JScramblerDeobfuscationFailed',
+        message: error instanceof Error ? error.message : 'Unknown error',
+        timestamp: new Date().toISOString(),
+        context: {
+          codePreview: code.substring(0, 500),
+          options,
+        },
       };
+      logger.error(`JScrambler deobfuscation failed: ${JSON.stringify(errorDetails)}`);
+      throw new Error(JSON.stringify(errorDetails));
     }
   }
 

--- a/src/modules/deobfuscator/PackerDeobfuscator.ts
+++ b/src/modules/deobfuscator/PackerDeobfuscator.ts
@@ -15,7 +15,11 @@ export interface PackerDeobfuscatorResult {
 }
 
 export class PackerDeobfuscator {
-  private readonly sandbox = new ExecutionSandbox();
+  private readonly sandbox: ExecutionSandbox;
+
+  constructor(sandbox?: ExecutionSandbox) {
+    this.sandbox = sandbox ?? new ExecutionSandbox();
+  }
 
   static detect(code: string): boolean {
     const packerPattern =
@@ -142,9 +146,13 @@ export class PackerDeobfuscator {
     const { p, a, k } = params;
     let { c } = params;
 
+    if (c <= 0 || k.length === 0) {
+      return p;
+    }
+
     let result = p;
 
-    while (c--) {
+    while (--c >= 0) {
       const replacement = k[c];
       if (replacement) {
         const pattern = new RegExp('\\b' + this.base(c, a) + '\\b', 'g');
@@ -170,22 +178,70 @@ export class PackerDeobfuscator {
 
     return result || '0';
   }
+}
 
-  beautify(code: string): string {
-    let result = code;
+export class Base64Decoder {
+  static detect(code: string): boolean {
+    return (
+      /(?:atob|btoa)\s*\(|eval\s*\(\s*atob\s*\(/.test(code) ||
+      /["'`][A-Za-z0-9+/]{40,}={0,2}["'`]/.test(code)
+    );
+  }
 
-    result = result.replace(/;/g, ';\n');
-    result = result.replace(/{/g, '{\n');
-    result = result.replace(/}/g, '\n}\n');
+  static decodeInlineAtob(code: string): string {
+    return code.replace(/atob\s*\(\s*["'`]([A-Za-z0-9+/\s]+={0,2})["'`]\s*\)/g, (_match, b64) => {
+      try {
+        return JSON.stringify(Buffer.from(b64.replace(/\s/g, ''), 'base64').toString('utf8'));
+      } catch {
+        return _match;
+      }
+    });
+  }
 
-    result = result.replace(/\n\n+/g, '\n\n');
+  async deobfuscate(code: string): Promise<string> {
+    logger.info('Base64: decoding inline atob() calls...');
+    try {
+      const decoded = Base64Decoder.decodeInlineAtob(code);
+      logger.info('Base64 decode complete');
+      return decoded;
+    } catch (error) {
+      logger.error('Base64 decode failed', error);
+      return code;
+    }
+  }
+}
 
-    return result.trim();
+export class HexStringDecoder {
+  static detect(code: string): boolean {
+    const hexEscapeCount = (code.match(/\\x[0-9a-fA-F]{1,2}/g) ?? []).length;
+    return hexEscapeCount >= 6;
+  }
+
+  static decode(code: string): string {
+    return code
+      .replace(/\\x([0-9a-fA-F]{1,2})/g, (_m, hex) => String.fromCharCode(parseInt(hex, 16)))
+      .replace(/\\u([0-9a-fA-F]{1,4})/g, (_m, hex) => String.fromCharCode(parseInt(hex, 16)));
+  }
+
+  async deobfuscate(code: string): Promise<string> {
+    logger.info('HexString: decoding escape sequences...');
+    try {
+      const decoded = HexStringDecoder.decode(code);
+      logger.info('HexString decode complete');
+      return decoded;
+    } catch (error) {
+      logger.error('HexString decode failed', error);
+      return code;
+    }
   }
 }
 
 export class AAEncodeDeobfuscator {
-  private readonly sandbox = new ExecutionSandbox();
+  private readonly sandbox: ExecutionSandbox;
+
+  constructor(sandbox?: ExecutionSandbox) {
+    this.sandbox = sandbox ?? new ExecutionSandbox();
+  }
 
   static detect(code: string): boolean {
     return code.includes('゜-゜') || code.includes('ω゜') || code.includes('o゜)');
@@ -227,59 +283,95 @@ export class URLEncodeDeobfuscator {
       logger.info(' URLEncode');
       return decoded;
     } catch (error) {
-      logger.error('URLEncode', error);
+      const message = error instanceof Error ? error.message : String(error);
+      if (message.includes('URIError') || message.includes(' malformed URI')) {
+        logger.warn(`URLEncode: skipped — code contains malformed percent-encoding (${message})`);
+      } else {
+        logger.error('URLEncode', error);
+      }
       return code;
     }
   }
 }
 
 export class UniversalUnpacker {
-  private packerDeobfuscator = new PackerDeobfuscator();
-  private aaencodeDeobfuscator = new AAEncodeDeobfuscator();
-  private urlencodeDeobfuscator = new URLEncodeDeobfuscator();
+  private readonly sandbox = new ExecutionSandbox();
+  private readonly packerDeobfuscator: PackerDeobfuscator;
+  private readonly aaencodeDeobfuscator: AAEncodeDeobfuscator;
+  private readonly urlencodeDeobfuscator = new URLEncodeDeobfuscator();
+  private readonly base64Decoder = new Base64Decoder();
+  private readonly hexStringDecoder = new HexStringDecoder();
+
+  constructor() {
+    this.packerDeobfuscator = new PackerDeobfuscator(this.sandbox);
+    this.aaencodeDeobfuscator = new AAEncodeDeobfuscator(this.sandbox);
+  }
 
   async deobfuscate(code: string): Promise<{
     code: string;
     type: string;
     success: boolean;
   }> {
-    logger.info(' ...');
+    logger.info('UniversalUnpacker: detecting encoding...');
 
-    if (PackerDeobfuscator.detect(code)) {
-      logger.info(': Packer');
-      const result = await this.packerDeobfuscator.deobfuscate({ code });
-      return {
-        code: result.code,
-        type: 'Packer',
-        success: result.success,
-      };
+    let currentCode = code;
+    let detectedType = 'Unknown';
+    let success = false;
+
+    if (PackerDeobfuscator.detect(currentCode)) {
+      logger.info('UniversalUnpacker: detected Packer');
+      const result = await this.packerDeobfuscator.deobfuscate({ code: currentCode });
+      if (result.success) {
+        currentCode = result.code;
+        detectedType = 'Packer';
+        success = true;
+      }
     }
 
-    if (AAEncodeDeobfuscator.detect(code)) {
-      logger.info(': AAEncode');
-      const decoded = await this.aaencodeDeobfuscator.deobfuscate(code);
-      return {
-        code: decoded,
-        type: 'AAEncode',
-        success: decoded !== code,
-      };
+    if (AAEncodeDeobfuscator.detect(currentCode)) {
+      logger.info('UniversalUnpacker: detected AAEncode');
+      const decoded = await this.aaencodeDeobfuscator.deobfuscate(currentCode);
+      if (decoded !== currentCode) {
+        currentCode = decoded;
+        detectedType = detectedType === 'Unknown' ? 'AAEncode' : `${detectedType}+AAEncode`;
+        success = true;
+      }
     }
 
-    if (URLEncodeDeobfuscator.detect(code)) {
-      logger.info(': URLEncode');
-      const decoded = await this.urlencodeDeobfuscator.deobfuscate(code);
-      return {
-        code: decoded,
-        type: 'URLEncode',
-        success: decoded !== code,
-      };
+    if (URLEncodeDeobfuscator.detect(currentCode)) {
+      logger.info('UniversalUnpacker: detected URLEncode');
+      const decoded = await this.urlencodeDeobfuscator.deobfuscate(currentCode);
+      if (decoded !== currentCode) {
+        currentCode = decoded;
+        detectedType = detectedType === 'Unknown' ? 'URLEncode' : `${detectedType}+URLEncode`;
+        success = true;
+      }
     }
 
-    logger.info('');
-    return {
-      code,
-      type: 'Unknown',
-      success: false,
-    };
+    if (HexStringDecoder.detect(currentCode)) {
+      logger.info('UniversalUnpacker: detected hex escape sequences');
+      const decoded = await this.hexStringDecoder.deobfuscate(currentCode);
+      if (decoded !== currentCode) {
+        currentCode = decoded;
+        detectedType = detectedType === 'Unknown' ? 'HexString' : `${detectedType}+HexString`;
+        success = true;
+      }
+    }
+
+    if (Base64Decoder.detect(currentCode)) {
+      logger.info('UniversalUnpacker: detected inline base64 (atob)');
+      const decoded = await this.base64Decoder.deobfuscate(currentCode);
+      if (decoded !== currentCode) {
+        currentCode = decoded;
+        detectedType = detectedType === 'Unknown' ? 'Base64' : `${detectedType}+Base64`;
+        success = true;
+      }
+    }
+
+    if (!success) {
+      logger.info('UniversalUnpacker: no recognized encoding detected');
+    }
+
+    return { code: currentCode, type: detectedType, success };
   }
 }

--- a/src/modules/deobfuscator/ProApiClient.ts
+++ b/src/modules/deobfuscator/ProApiClient.ts
@@ -1,0 +1,222 @@
+import type { DeobfuscateOptions, DeobfuscateResult, ObfuscationType } from '@internal-types/index';
+import { DEOBFUSCATION_CONFIG, withTimeout } from '@modules/deobfuscator/DeobfuscationConfig';
+
+interface ObfuscatorProConfig {
+  apiToken: string;
+  version?: string;
+  timeout?: number;
+}
+
+interface ObfuscatorProOptions {
+  vmObfuscation?: boolean;
+  parseHtml?: boolean;
+}
+
+interface ObfuscatorProResult {
+  getObfuscatedCode: () => string;
+  getSourceMap?: () => string;
+}
+
+interface ObfuscatorProClient {
+  obfuscatePro: (
+    sourceCode: string,
+    options: ObfuscatorProOptions,
+    config: ObfuscatorProConfig,
+  ) => Promise<ObfuscatorProResult>;
+}
+
+interface ProApiDeobfuscatorOptions extends DeobfuscateOptions {
+  proApiToken?: string;
+  proApiVersion?: string;
+  vmObfuscation?: boolean;
+  parseHtml?: boolean;
+}
+
+interface ProApiDeobfuscateResult extends DeobfuscateResult {
+  proApiUsed: boolean;
+  proApiConfig?: ObfuscatorProConfig;
+}
+
+// Cache for the javascript-obfuscator module to prevent repeated dynamic imports
+let jsObfuscatorModule: typeof import('javascript-obfuscator') | null = null;
+let moduleLoadAttempted = false;
+let moduleLoadPromise: Promise<typeof import('javascript-obfuscator') | null> | null = null;
+
+async function getJsObfuscatorModule(): Promise<typeof import('javascript-obfuscator') | null> {
+  if (jsObfuscatorModule !== null) {
+    return jsObfuscatorModule;
+  }
+
+  if (moduleLoadAttempted) {
+    return null;
+  }
+
+  if (moduleLoadPromise !== null) {
+    return moduleLoadPromise;
+  }
+
+  moduleLoadAttempted = true;
+  moduleLoadPromise = withTimeout(
+    (async () => {
+      try {
+        const module = await import('javascript-obfuscator');
+        jsObfuscatorModule = module;
+        return module;
+      } catch (error) {
+        console.warn('Failed to load javascript-obfuscator module:', error);
+        return null;
+      }
+    })(),
+    DEOBFUSCATION_CONFIG.PRO_API_TIMEOUT_MS,
+    'javascript-obfuscator module load timeout',
+  ).catch(() => null);
+
+  return moduleLoadPromise;
+}
+
+export function getProApiClientStatus(): 'valid' | 'invalid' | 'unknown' {
+  const token = process.env.OBFUSCATOR_IO_API_TOKEN;
+  if (!token) {
+    return 'unknown';
+  }
+
+  return token.length >= DEOBFUSCATION_CONFIG.MIN_API_TOKEN_LENGTH ? 'valid' : 'invalid';
+}
+
+export function hasProFeatures(options: DeobfuscateOptions): boolean {
+  return (
+    !!(options as ProApiDeobfuscatorOptions).proApiToken ||
+    (options as ObfuscatorProOptions).vmObfuscation === true ||
+    (options as ObfuscatorProOptions).parseHtml === true
+  );
+}
+
+export function hasValidProApiToken(): boolean {
+  const token = process.env.OBFUSCATOR_IO_API_TOKEN;
+  return !!token && token.length >= DEOBFUSCATION_CONFIG.MIN_API_TOKEN_LENGTH;
+}
+
+export async function deobfuscateWithProApi(
+  options: DeobfuscateOptions,
+): Promise<ProApiDeobfuscateResult | null> {
+  const proOptions = options as ProApiDeobfuscatorOptions;
+  const proToken = proOptions.proApiToken || process.env.OBFUSCATOR_IO_API_TOKEN;
+
+  // Validation with proper error messages
+  if (!proToken) {
+    console.debug('Pro API token not provided');
+    return null;
+  }
+
+  if (proToken.length < DEOBFUSCATION_CONFIG.MIN_API_TOKEN_LENGTH) {
+    console.warn(
+      `Pro API token too short (min ${DEOBFUSCATION_CONFIG.MIN_API_TOKEN_LENGTH} chars)`,
+    );
+    return null;
+  }
+
+  const module = await getJsObfuscatorModule();
+  if (!module) {
+    console.warn('javascript-obfuscator module not available');
+    return null;
+  }
+
+  try {
+    const apiOptions: ObfuscatorProOptions = {
+      vmObfuscation: proOptions.vmObfuscation === true,
+      parseHtml: proOptions.parseHtml === true,
+    };
+
+    const apiConfig: ObfuscatorProConfig = {
+      apiToken: '[REDACTED]', // Don't expose the actual token
+      version: proOptions.proApiVersion || process.env.OBFUSCATOR_IO_VERSION,
+      timeout: DEOBFUSCATION_CONFIG.PRO_API_TIMEOUT_MS,
+    };
+
+    // Use timeout for the API call
+    const result = await withTimeout(
+      module.obfuscatePro(options.code, apiOptions, {
+        apiToken: proToken,
+        version: apiConfig.version,
+        timeout: DEOBFUSCATION_CONFIG.PRO_API_TIMEOUT_MS,
+      }),
+      DEOBFUSCATION_CONFIG.PRO_API_TIMEOUT_MS,
+      'Pro API deobfuscation timeout',
+    );
+
+    if (result && typeof result.getObfuscatedCode === 'function') {
+      return {
+        code: result.getObfuscatedCode(),
+        readabilityScore: 0,
+        confidence: 0.9,
+        obfuscationType: ['javascript-obfuscator'] as ObfuscationType[],
+        transformations: [],
+        analysis: 'obfuscator.io Pro API applied',
+        proApiUsed: true,
+        proApiConfig: {
+          apiToken: '[REDACTED]', // Don't expose actual token
+          version: apiConfig.version,
+          timeout: apiConfig.timeout,
+        },
+        engine: 'pro-api',
+        cached: false,
+      };
+    }
+  } catch (error) {
+    console.error('Pro API deobfuscation failed:', (error as Error).message);
+    return null;
+  }
+
+  return null;
+}
+
+export const ProApiClient = {
+  loadClient: async (): Promise<ObfuscatorProClient | null> => {
+    const module = await getJsObfuscatorModule();
+    if (!module) return null;
+
+    return {
+      obfuscatePro: module.obfuscatePro.bind(module),
+    };
+  },
+
+  obfuscatePro: async (
+    sourceCode: string,
+    options: ObfuscatorProOptions,
+    config: ObfuscatorProConfig,
+  ): Promise<{ code: string; applier: string } | null> => {
+    const client = await ProApiClient.loadClient();
+    if (!client) {
+      return null;
+    }
+
+    try {
+      const result = await withTimeout(
+        client.obfuscatePro(sourceCode, options, {
+          apiToken: config.apiToken,
+          version: config.version,
+          timeout: config.timeout || DEOBFUSCATION_CONFIG.PRO_API_TIMEOUT_MS,
+        }),
+        config.timeout || DEOBFUSCATION_CONFIG.PRO_API_TIMEOUT_MS,
+        'Pro API deobfuscation timeout',
+      );
+
+      return {
+        code: result.getObfuscatedCode(),
+        applier: 'javascript-obfuscator',
+      };
+    } catch (error) {
+      console.error('Pro API obfuscation failed:', (error as Error).message);
+      return null;
+    }
+  },
+
+  getApiTokenStatus: getProApiClientStatus,
+};
+
+export default {
+  deobfuscateWithProApi,
+  hasProFeatures,
+  hasValidProApiToken,
+  ProApiClient,
+};

--- a/src/modules/deobfuscator/VMDeobfuscator.ts
+++ b/src/modules/deobfuscator/VMDeobfuscator.ts
@@ -1,5 +1,6 @@
 import { logger } from '@utils/logger';
 import * as parser from '@babel/parser';
+import generate from '@babel/generator';
 import traverse from '@babel/traverse';
 import type { NodePath } from '@babel/traverse';
 import * as t from '@babel/types';
@@ -9,12 +10,22 @@ type VMStructure = {
   instructionTypes: string[];
   hasStack: boolean;
   hasRegisters: boolean;
+  hasDispatcher: boolean;
+  hasStateVariable: boolean;
 };
 
 type VMComponents = {
   instructionArray?: string;
   dataArray?: string;
   interpreterFunction?: string;
+  stateVariable?: string;
+  dispatcherVariable?: string;
+};
+
+type VMInstruction = {
+  opCode: string;
+  handler: string;
+  operands: string[];
 };
 
 export class VMDeobfuscator {
@@ -32,6 +43,8 @@ export class VMDeobfuscator {
       /var\s+\w+\s*=\s*\[\s*\d+(?:\s*,\s*\d+){10,}\s*\]/i,
       /\w+\[pc\+\+\]/i,
       /stack\.push|stack\.pop/i,
+      /dispatcher|interpreter/i,
+      /\bpc\s*\+\+|pc\s*=\s*\w+/i,
     ];
 
     const matchCount = vmPatterns.filter((pattern) => pattern.test(code)).length;
@@ -68,8 +81,8 @@ export class VMDeobfuscator {
       }
 
       const vmComponents = this.extractVMComponents(code);
-
-      const simplifiedCode = this.simplifyVMCode(code, vmComponents);
+      const instructions = this.extractVMInstructions(code);
+      const simplifiedCode = this.simplifyVMCode(code, vmComponents, instructions);
 
       return {
         success: simplifiedCode !== code,
@@ -87,6 +100,8 @@ export class VMDeobfuscator {
       instructionTypes: [],
       hasStack: false,
       hasRegisters: false,
+      hasDispatcher: false,
+      hasStateVariable: false,
     };
 
     if (/while\s*\(\s*true\s*\)|for\s*\(\s*;\s*;\s*\)/.test(code)) {
@@ -101,12 +116,20 @@ export class VMDeobfuscator {
       );
     }
 
-    if (/\.push\(|\.pop\(/.test(code)) {
+    if (/\.push\(|\.pop\(/.test(code) || /var\s+\w+\s*=\s*\[\s*\]\s*;?/.test(code)) {
       structure.hasStack = true;
     }
 
-    if (/r\d+\s*=|reg\[\d+\]/.test(code)) {
+    if (/r\d+\s*=|(?:reg|state)\[\d+\]/i.test(code)) {
       structure.hasRegisters = true;
+    }
+
+    if (/dispatcher|case\s+\w+\s*:/i.test(code)) {
+      structure.hasDispatcher = true;
+    }
+
+    if (/\b(pc|ip|sp|fp)\s*[=+]/.test(code)) {
+      structure.hasStateVariable = true;
     }
 
     return structure;
@@ -137,6 +160,13 @@ export class VMDeobfuscator {
               }
             }
           }
+
+          if (t.isIdentifier(path.node.id)) {
+            const name = path.node.id.name;
+            if (/^(pc|ip|sp|fp|state|ctx)$/i.test(name)) {
+              components.stateVariable = name;
+            }
+          }
         },
 
         FunctionDeclaration(path: NodePath<t.FunctionDeclaration>) {
@@ -159,6 +189,25 @@ export class VMDeobfuscator {
             components.interpreterFunction = path.node.id.name;
           }
         },
+
+        AssignmentExpression(assignPath: NodePath<t.AssignmentExpression>) {
+          const left = assignPath.node.left;
+          const right = assignPath.node.right;
+
+          if (t.isIdentifier(left) && /^(dispatcher|dispatch)$/i.test(left.name)) {
+            components.dispatcherVariable = left.name;
+          }
+
+          if (
+            t.isMemberExpression(right) &&
+            t.isIdentifier(right.object) &&
+            right.object.name === 'dispatcher'
+          ) {
+            components.dispatcherVariable = t.isIdentifier(left)
+              ? left.name
+              : components.dispatcherVariable;
+          }
+        },
       });
     } catch (error) {
       logger.debug('Failed to extract VM components:', error);
@@ -167,13 +216,122 @@ export class VMDeobfuscator {
     return components;
   }
 
-  public simplifyVMCode(code: string, vmComponents: VMComponents): string {
+  public extractVMInstructions(code: string): VMInstruction[] {
+    const instructions: VMInstruction[] = [];
+
+    // Try Babel AST extraction first
+    try {
+      const ast = parser.parse(code, {
+        sourceType: 'module',
+        plugins: ['jsx', 'typescript'],
+      });
+
+      traverse(ast, {
+        SwitchStatement(switchPath: NodePath<t.SwitchStatement>) {
+          if (switchPath.node.cases.length >= 2) {
+            for (const switchCase of switchPath.node.cases) {
+              let opCode = '';
+              let handler = '';
+              const operands: string[] = [];
+
+              if (t.isNumericLiteral(switchCase.test)) {
+                opCode = String(switchCase.test.value);
+              } else if (t.isIdentifier(switchCase.test)) {
+                opCode = switchCase.test.name;
+              } else if (t.isStringLiteral(switchCase.test)) {
+                opCode = switchCase.test.value;
+              }
+
+              for (const consequent of switchCase.consequent) {
+                const stmtCode = generate(consequent).code;
+
+                if (!handler) {
+                  if (/push\s*\(|pop\s*\(/.test(stmtCode)) {
+                    handler = 'stack';
+                  } else if (/charCodeAt|String\.fromCharCode/.test(stmtCode)) {
+                    handler = 'string';
+                  } else if (/\[.*\]\s*=/.test(stmtCode)) {
+                    handler = 'memory';
+                  } else if (/console\.log|return/.test(stmtCode)) {
+                    handler = 'io';
+                  }
+                }
+
+                const varMatches = stmtCode.match(/\b(var|let|const)\s+(\w+)/g);
+                if (varMatches) {
+                  for (const match of varMatches) {
+                    const varName = match.replace(/^(var|let|const)\s+/, '');
+                    if (!operands.includes(varName)) {
+                      operands.push(varName);
+                    }
+                  }
+                }
+              }
+
+              if (opCode) {
+                instructions.push({ opCode, handler, operands });
+              }
+            }
+          }
+        },
+      });
+    } catch (error) {
+      logger.debug('Failed to extract VM instructions via AST, falling back to regex:', error);
+    }
+
+    // Fallback: regex-based extraction if AST failed or returned empty
+    if (instructions.length === 0) {
+      const casePattern = /case\s+(\S+?)\s*:\s*([^}]+?)(?=\bcase\b|$)/g;
+      let match;
+
+      while ((match = casePattern.exec(code)) !== null) {
+        const opCode = (match[1] ?? '').replace(/['"`]/g, '');
+        const body = match[2] ?? '';
+        let handler = '';
+
+        if (!handler) {
+          if (/push\s*\(|pop\s*\(/.test(body)) {
+            handler = 'stack';
+          } else if (/charCodeAt|String\.fromCharCode/.test(body)) {
+            handler = 'string';
+          } else if (/\[.*\]\s*=/.test(body)) {
+            handler = 'memory';
+          } else if (/console\.log|return/.test(body)) {
+            handler = 'io';
+          }
+        }
+
+        const operands: string[] = [];
+        const varMatches = body.match(/\b(var|let|const)\s+(\w+)/g);
+        if (varMatches) {
+          for (const v of varMatches) {
+            const varName = v.replace(/^(var|let|const)\s+/, '');
+            if (!operands.includes(varName)) {
+              operands.push(varName);
+            }
+          }
+        }
+
+        if (opCode) {
+          instructions.push({ opCode, handler, operands });
+        }
+      }
+    }
+
+    return instructions;
+  }
+
+  public simplifyVMCode(
+    code: string,
+    vmComponents: VMComponents,
+    instructions: VMInstruction[] = [],
+  ): string {
     try {
       let simplified = code;
 
       if (vmComponents.interpreterFunction) {
         const regex = new RegExp(
-          `function\\s+${vmComponents.interpreterFunction}\\s*\\([^)]*\\)\\s*\\{[^}]*\\}`,
+          `function\\s+${vmComponents.interpreterFunction}\\s*\\([^)]*\\)\\s*\\{[^}]*(?:\\{[^}]*\\}[^}]*)*\\}`,
           'g',
         );
         simplified = simplified.replace(regex, '/* vm interpreter removed */');
@@ -181,16 +339,85 @@ export class VMDeobfuscator {
 
       if (vmComponents.instructionArray) {
         const regex = new RegExp(
-          `var\\s+${vmComponents.instructionArray}\\s*=\\s*\\[[^\\]]*\\];`,
+          `var\\s+${vmComponents.instructionArray}\\s*=\\s*\\[[^\\]]*\\];?`,
           'g',
         );
         simplified = simplified.replace(regex, '/* vm instruction array removed */');
       }
+
+      if (vmComponents.dataArray) {
+        const regex = new RegExp(`var\\s+${vmComponents.dataArray}\\s*=\\s*\\[[^\\]]*\\];?`, 'g');
+        simplified = simplified.replace(regex, '/* vm data array removed */');
+      }
+
+      if (vmComponents.stateVariable) {
+        const regex = new RegExp(`var\\s+${vmComponents.stateVariable}\\s*=\\s*[^;]+;`, 'g');
+        simplified = simplified.replace(regex, `/* vm state removed */`);
+      }
+
+      if (instructions.length > 0) {
+        simplified = this.simplifyOpaquePredicates(simplified);
+      }
+
+      simplified = this.removeVMGuards(simplified);
 
       return simplified;
     } catch (error) {
       logger.debug('Failed to simplify VM code:', error);
       return code;
     }
+  }
+
+  private simplifyOpaquePredicates(code: string): string {
+    try {
+      const ast = parser.parse(code, {
+        sourceType: 'module',
+        plugins: ['jsx', 'typescript'],
+      });
+
+      traverse(ast, {
+        IfStatement(ifPath: NodePath<t.IfStatement>) {
+          const test = ifPath.node.test;
+
+          if (
+            t.isBinaryExpression(test) &&
+            t.isNumericLiteral(test.left) &&
+            t.isNumericLiteral(test.right)
+          ) {
+            const result =
+              test.operator === '==='
+                ? test.left.value === test.right.value
+                : test.operator === '!=='
+                  ? test.left.value !== test.right.value
+                  : null;
+
+            if (result === true) {
+              ifPath.replaceWithMultiple(ifPath.node.consequent);
+            } else if (result === false && ifPath.node.alternate) {
+              ifPath.replaceWithMultiple(ifPath.node.alternate);
+            } else if (result === false) {
+              ifPath.remove();
+            }
+          }
+        },
+      });
+
+      return generate(ast, { comments: false, compact: false }).code;
+    } catch {
+      return code;
+    }
+  }
+
+  private removeVMGuards(code: string): string {
+    let simplified = code;
+
+    simplified = simplified.replace(
+      /if\s*\(\s*['"`]\w+['"`]\s*===\s*['"`]\w+['"`]\s*\)\s*\{[\s\S]*?debugger[\s\S]*?\}\s*/gi,
+      '',
+    );
+
+    simplified = simplified.replace(/try\s*\{[\s\S]*?\}\s*catch\s*\(\s*\w+\s*\)\s*\{\s*\}/g, '');
+
+    return simplified;
   }
 }

--- a/src/modules/deobfuscator/webcrack.ts
+++ b/src/modules/deobfuscator/webcrack.ts
@@ -1,4 +1,4 @@
-import { readdir, rm, stat } from 'node:fs/promises';
+import { readdir, realpath, rm, stat } from 'node:fs/promises';
 import path from 'node:path';
 import type {
   DeobfuscateBundleModuleSummary,
@@ -17,7 +17,7 @@ type WebcrackModuleLike = {
 };
 
 type WebcrackBundleLike = {
-  type: 'webpack' | 'browserify';
+  type: 'webpack' | 'browserify' | 'vite' | 'rollup' | 'parcel' | (string & {});
   entryId: string;
   modules: Map<string, WebcrackModuleLike>;
 };
@@ -107,7 +107,11 @@ function isSupportedNodeVersion(): boolean {
     return minor >= 12;
   }
 
-  return major > 22;
+  if (major === 23) {
+    return true;
+  }
+
+  return major >= 24;
 }
 
 function matchesRule(module: WebcrackModuleLike, rule: DeobfuscateMappingRule): boolean {
@@ -237,18 +241,21 @@ export async function runWebcrack(
     };
   }
 
-  const sandboxOption: unknown = undefined;
+  let hasIsolatedVm = false;
   try {
     // @ts-expect-error -- optional dependency that may fail to compile on Node 24+
     await import('isolated-vm');
-  } catch {
-    // SECURITY: Do NOT fall back to node:vm — it is not a security boundary.
-    // Without isolated-vm, webcrack runs without a custom sandbox.
-    // Deobfuscation of untrusted code is not recommended in this mode.
+    hasIsolatedVm = true;
+    logger.debug('isolated-vm available, webcrack sandbox enabled');
+  } catch (err) {
+    // Do NOT fall back to node:vm — it is not a security boundary and allows
+    // host escape via `this.constructor.constructor('return process')()`.
+    // webcrack will run without a sandbox when isolated-vm is unavailable.
     logger.warn(
-      'isolated-vm is unavailable (likely Node 24 incompatibility). ' +
-        'Deobfuscation sandbox is disabled — do not process untrusted code.',
+      'isolated-vm is unavailable or failed to load. webcrack will run without a sandbox — ' +
+        'do not process untrusted samples in this configuration.',
     );
+    logger.debug('isolated-vm load error:', err);
   }
 
   try {
@@ -259,7 +266,7 @@ export async function runWebcrack(
       deobfuscate: true,
       unminify: optionsUsed.unminify,
       mangle: optionsUsed.mangle,
-      ...(sandboxOption ? { sandbox: sandboxOption } : {}),
+      ...(hasIsolatedVm ? { sandbox: 'isolated-vm' } : { sandbox: false }),
     });
 
     const remapped = result.bundle
@@ -269,23 +276,36 @@ export async function runWebcrack(
     let savedTo: string | undefined;
     let savedArtifacts: DeobfuscateSavedArtifact[] | undefined;
     if (typeof options.outputDir === 'string' && options.outputDir.trim().length > 0) {
-      savedTo = path.resolve(options.outputDir);
-
-      // SECURITY: Ensure outputDir stays within cwd or a safe parent.
-      // Reject absolute paths outside the project and any path traversal.
-      const cwd = process.cwd();
-      const relFromCwd = path.relative(cwd, savedTo);
-      if (
-        path.isAbsolute(relFromCwd) ||
-        relFromCwd.startsWith('..') ||
-        savedTo === '/' ||
-        savedTo === path.parse(savedTo).root
-      ) {
-        throw new Error(
-          `outputDir must resolve to a path within the project root. Got: ${savedTo}`,
-        );
+      const baseDir = path.normalize(process.cwd());
+      const resolved = path.resolve(baseDir, options.outputDir);
+      // Guard against path traversal: outputDir must be within the current working directory.
+      if (!resolved.startsWith(baseDir + path.sep) && resolved !== baseDir) {
+        const reason = `outputDir escapes the working directory: ${options.outputDir}`;
+        logger.warn(reason);
+        return {
+          applied: false,
+          code,
+          optionsUsed,
+          reason,
+        };
       }
-
+      // Guard against symlink escape: resolve the real path and verify it's still within baseDir.
+      try {
+        const real = await realpath(resolved);
+        if (!real.startsWith(baseDir + path.sep) && real !== baseDir) {
+          const reason = `outputDir resolves via symlink outside working directory: ${options.outputDir}`;
+          logger.warn(reason);
+          return {
+            applied: false,
+            code,
+            optionsUsed,
+            reason,
+          };
+        }
+      } catch {
+        // Path doesn't exist yet — symlink check only applies post-creation, acceptable.
+      }
+      savedTo = resolved;
       if (options.forceOutput) {
         await rm(savedTo, { recursive: true, force: true });
       }

--- a/src/server/MCPServer.transport.ts
+++ b/src/server/MCPServer.transport.ts
@@ -90,7 +90,7 @@ export async function startHttpTransport(ctx: MCPServerContext): Promise<void> {
 
     // Health check endpoint — no auth, no rate limit
     if (url.pathname === '/health' && req.method === 'GET') {
-      handleHealthCheck(ctx, res);
+      handleHealthCheck(ctx, req, res);
       return;
     }
 
@@ -152,13 +152,29 @@ export async function startHttpTransport(ctx: MCPServerContext): Promise<void> {
 
 // ── Health check ──
 
-import type { ServerResponse as HttpServerResponse } from 'node:http';
+import type { IncomingMessage, ServerResponse as HttpServerResponse } from 'node:http';
 
-function handleHealthCheck(ctx: MCPServerContext, res: HttpServerResponse): void {
+function handleHealthCheck(
+  ctx: MCPServerContext,
+  req: IncomingMessage,
+  res: HttpServerResponse,
+): void {
   // Minimal output by default to avoid exposing internal state (domains, tool
-  // counts, token budget). Full details are gated behind MCP_AUTH_TOKEN or
+  // counts, token budget). Verbose details require authentication or
   // MCP_HEALTH_VERBOSE=true for trusted environments.
-  const verbose = ['1', 'true'].includes((process.env.MCP_HEALTH_VERBOSE ?? '').toLowerCase());
+  const url = new URL(req.url ?? '/', 'http://localhost');
+  const verboseRequested = url.searchParams.get('verbose') === 'true';
+  const envVerboseAllowed = ['1', 'true'].includes(
+    (process.env.MCP_HEALTH_VERBOSE ?? '').toLowerCase(),
+  );
+
+  let authenticated = true;
+  if (verboseRequested && !envVerboseAllowed) {
+    authenticated = checkAuth(req, res);
+    if (!authenticated) return; // checkAuth has already responded with 401
+  }
+
+  const verbose = verboseRequested && (authenticated || envVerboseAllowed);
 
   const body: Record<string, unknown> = {
     status: 'ok',
@@ -166,17 +182,12 @@ function handleHealthCheck(ctx: MCPServerContext, res: HttpServerResponse): void
   };
 
   if (verbose) {
-    const budgetStats = ctx.tokenBudget.getStats();
     body.tier = ctx.baseTier;
     body.baseTier = ctx.baseTier;
     body.enabledDomains = [...ctx.enabledDomains];
     body.registeredTools = ctx.selectedTools.length;
     body.activatedTools = ctx.activatedToolNames.size;
-    body.tokenBudget = {
-      usagePercentage: budgetStats.usagePercentage,
-      currentUsage: budgetStats.currentUsage,
-      maxTokens: budgetStats.maxTokens,
-    };
+    // Removed sensitive token budget details from responses
   }
 
   res.writeHead(200, { 'Content-Type': 'application/json' });

--- a/src/server/domains/sourcemap/handlers.impl.sourcemap-main.ts
+++ b/src/server/domains/sourcemap/handlers.impl.sourcemap-main.ts
@@ -1,5 +1,6 @@
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
+import { writeFileSecure } from '@utils/secure-files';
 import type {
   CdpSessionLike,
   DiscoverItem,
@@ -168,8 +169,7 @@ export class SourcemapToolHandlersMain extends SourcemapToolHandlersExtension {
             : `/* source content missing in source map: ${sourcePath} */\n`;
 
         try {
-          await mkdir(dirname(absolutePath), { recursive: true });
-          await writeFile(absolutePath, fileContent, 'utf-8');
+          await writeFileSecure(absolutePath, fileContent, { encoding: 'utf-8' });
           writtenFiles.push(relativePath);
         } catch {
           skippedFiles += 1;

--- a/src/server/http/HttpMiddleware.ts
+++ b/src/server/http/HttpMiddleware.ts
@@ -1,6 +1,7 @@
 /**
  * HTTP middleware for MCP Streamable HTTP transport.
  *
+ * - Security headers (X-Content-Type-Options, X-Frame-Options, etc.) except on health checks
  * - Bearer token authentication (opt-in via MCP_AUTH_TOKEN env)
  * - Origin validation to prevent CSRF on localhost
  * - Request body size limiting (default 10 MB)
@@ -268,4 +269,26 @@ export function checkRateLimit(
 
   entry.timestamps.push(now);
   return true;
+}
+
+// ── Security headers ──
+
+/**
+ * Applies comprehensive security headers to HTTP responses.
+ * Excludes health check endpoints to avoid interfering with monitoring.
+ */
+export function applySecurityHeaders(req: IncomingMessage, res: ServerResponse): void {
+  // Skip security headers for health checks
+  if (req.url?.startsWith('/health')) {
+    return;
+  }
+
+  // Set security headers
+  res.setHeader('X-Content-Type-Options', 'nosniff');
+  res.setHeader('X-Frame-Options', 'DENY');
+  res.setHeader('X-XSS-Protection', '1; mode=block');
+  res.setHeader('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
+  res.setHeader('Content-Security-Policy', "default-src 'self'");
+  res.setHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
+  res.setHeader('Permissions-Policy', 'geolocation=(), microphone=(), camera=()');
 }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -5,6 +5,7 @@ export interface Config {
   paths: PathsConfig;
   performance: PerformanceConfig;
   search: SearchConfig;
+  validation: ValidationConfig;
 }
 
 export interface PuppeteerConfig {
@@ -77,4 +78,127 @@ export interface SearchIntentToolBoostRuleConfig {
     tool: string;
     bonus: number;
   }>;
+}
+
+export interface ValidationConfig {
+  // URLs
+  captchaSolverBaseUrl?: string;
+  extensionRegistryBaseUrl?: string;
+  burpMcpSseUrl?: string;
+
+  // Ports
+  mcpPort?: number;
+  defaultDebugPort?: number;
+
+  // API Keys/Tokens
+  captchaApiKey?: string;
+  mcpAuthToken?: string;
+  mcpPluginSignatureSecret?: string;
+
+  // Logging and runtime
+  logLevel: string;
+  runtimeErrorWindowMs: number;
+  runtimeErrorThreshold: number;
+
+  // HTTP and transport
+  mcpTransport: string;
+  mcpHost: string;
+  mcpAllowInsecure: boolean;
+  mcpMaxBodyBytes: number;
+  mcpRateLimitWindowMs: number;
+  mcpRateLimitMax: number;
+  mcpHttpRequestTimeoutMs: number;
+  mcpHttpHeadersTimeoutMs: number;
+  mcpHttpKeepaliveTimeoutMs: number;
+  mcpHttpForceCloseTimeoutMs: number;
+
+  // Tool and plugin configuration
+  mcpToolProfile: string;
+  mcpToolDomains?: string;
+  mcpDefaultPluginBoostTier: string;
+  mcpPluginRoots?: string;
+  mcpWorkflowRoots?: string;
+  mcpPluginAllowedDigests?: string;
+  mcpPluginSignatureRequired?: boolean;
+  mcpPluginStrictLoad?: boolean;
+
+  // Cache and performance
+  cacheGlobalMaxSizeBytes: number;
+  tokenBudgetMaxTokens: number;
+  detailedDataDefaultTtlMs: number;
+  detailedDataMaxTtlMs: number;
+  detailedDataSmartThresholdBytes: number;
+  jshookIoConcurrency: number;
+  jshookCpuConcurrency: number;
+  jshookCdpConcurrency: number;
+
+  // Worker pools
+  workerPoolMinWorkers: number;
+  workerPoolMaxWorkers: number;
+  workerPoolIdleTimeoutMs: number;
+  workerPoolJobTimeoutMs: number;
+
+  // Parallel execution
+  parallelDefaultConcurrency: number;
+  parallelDefaultTimeoutMs: number;
+  parallelDefaultMaxRetries: number;
+  parallelRetryBackoffBaseMs: number;
+
+  // External tools and sandbox
+  externalToolTimeoutMs: number;
+  externalToolProbeTimeoutMs: number;
+  externalToolProbeCacheTtlMs: number;
+  externalToolForceKillGraceMs: number;
+  externalToolMaxStdoutBytes: number;
+  externalToolMaxStderrBytes: number;
+  sandboxExecTimeoutMs: number;
+  sandboxMemoryLimitMb: number;
+  sandboxStackSizeMb: number;
+  sandboxTerminateGraceMs: number;
+
+  // Symbolic execution
+  symbolicExecMaxPaths: number;
+  symbolicExecMaxDepth: number;
+  symbolicExecTimeoutMs: number;
+  packerSandboxTimeoutMs: number;
+
+  // LLM token limits
+  advDeobfLlmMaxTokens: number;
+  vmDeobfLlmMaxTokens: number;
+  deobfLlmMaxTokens: number;
+  cryptoDetectLlmMaxTokens: number;
+
+  // Workflow batch processing
+  workflowBatchMaxRetries: number;
+  workflowBatchMaxTimeoutMs: number;
+  workflowBundleCacheTtlMs: number;
+  workflowBundleCacheMaxBytes: number;
+
+  // Memory operations
+  memoryReadTimeoutMs: number;
+  memoryMaxReadBytes: number;
+  memoryWriteTimeoutMs: number;
+  memoryMaxWriteBytes: number;
+  memoryDumpTimeoutMs: number;
+  memoryScanTimeoutMs: number;
+  memoryScanMaxBufferBytes: number;
+  memoryScanMaxResults: number;
+  memoryScanMaxRegions: number;
+  memoryScanRegionMaxBytes: number;
+  memoryInjectTimeoutMs: number;
+  memoryMonitorIntervalMs: number;
+  memoryVmMapTimeoutMs: number;
+  memoryProtectionQueryTimeoutMs: number;
+  memoryProtectionPwshTimeoutMs: number;
+
+  // Native operations
+  nativeAdminCheckTimeoutMs: number;
+  nativeScanMaxResults: number;
+  processLaunchWaitMs: number;
+  winDebugPortPollAttempts: number;
+  winDebugPortPollIntervalMs: number;
+
+  // CAPTCHA
+  captchaProvider: string;
+  captchaDefaultTimeoutMs: number;
 }

--- a/src/types/deobfuscator.ts
+++ b/src/types/deobfuscator.ts
@@ -24,7 +24,12 @@ export type ObfuscationType =
   | 'unminify'
   | 'jsx-decompile'
   | 'mangle'
-  | 'webcrack';
+  | 'webcrack'
+  | 'jsdecode'
+  | 'hidden-properties'
+  | 'encoded-calls'
+  | 'proxy-obfuscation'
+  | 'with-obfuscation';
 
 export interface Transformation {
   type: string;
@@ -47,6 +52,10 @@ export interface DeobfuscateOptions {
   includeModuleCode?: boolean;
   maxBundleModules?: number;
   mappings?: DeobfuscateMappingRule[];
+  proApiToken?: string;
+  proApiVersion?: string;
+  vmObfuscation?: boolean;
+  parseHtml?: boolean;
 }
 
 export interface DeobfuscateMappingRule {
@@ -72,7 +81,7 @@ export interface DeobfuscateBundleModuleSummary {
 }
 
 export interface DeobfuscateBundleSummary {
-  type: 'webpack' | 'browserify';
+  type: 'webpack' | 'browserify' | 'vite' | 'rollup' | 'parcel' | (string & {});
   entryId: string;
   moduleCount: number;
   truncated: boolean;
@@ -91,7 +100,8 @@ export interface DeobfuscateResult {
   savedTo?: string;
   savedArtifacts?: DeobfuscateSavedArtifact[];
   warnings?: string[];
-  engine?: 'legacy' | 'webcrack' | 'hybrid';
+  engine?: 'legacy' | 'webcrack' | 'pro-api' | 'hybrid';
   webcrackApplied?: boolean;
+  proApiUsed?: boolean;
   cached?: boolean;
 }

--- a/src/types/escodegen.d.ts
+++ b/src/types/escodegen.d.ts
@@ -1,0 +1,1 @@
+declare module 'escodegen';

--- a/src/types/groq-sdk.d.ts
+++ b/src/types/groq-sdk.d.ts
@@ -1,0 +1,1 @@
+declare module 'groq-sdk';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,6 +9,7 @@ export type {
   SearchQueryCategoryProfileConfig,
   SearchCjkQueryAliasConfig,
   SearchIntentToolBoostRuleConfig,
+  ValidationConfig,
 } from '@internal-types/config';
 export type { BrowserContext } from '@internal-types/browser';
 export type {

--- a/src/types/javascript-obfuscator-pro.d.ts
+++ b/src/types/javascript-obfuscator-pro.d.ts
@@ -1,0 +1,18 @@
+declare module 'javascript-obfuscator' {
+  export function obfuscatePro(
+    sourceCode: string,
+    options: {
+      vmObfuscation?: boolean;
+      parseHtml?: boolean;
+      compact?: boolean;
+    },
+    config: {
+      apiToken: string;
+      version?: string;
+      timeout?: number;
+    },
+  ): Promise<{
+    getObfuscatedCode(): string;
+    getSourceMap?(): string;
+  }>;
+}

--- a/src/types/shift-parser.d.ts
+++ b/src/types/shift-parser.d.ts
@@ -1,0 +1,1 @@
+declare module 'shift-parser';

--- a/src/utils/artifacts.ts
+++ b/src/utils/artifacts.ts
@@ -50,7 +50,7 @@ export async function resolveArtifactPath(options: {
     );
   }
 
-  await mkdir(dir, { recursive: true });
+  await mkdir(dir, { recursive: true, mode: 0o755 });
 
   const ts = new Date().toISOString().replace(/[:.]/g, '-').replace('T', '_').slice(0, 19);
   const shortId = Math.random().toString(36).substring(2, 8);

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -3,6 +3,7 @@ import { join } from 'path';
 import { createHash } from 'crypto';
 import type { CacheConfig } from '@internal-types/index';
 import { logger } from '@utils/logger';
+import { writeFileSecure, mkdirSecure } from '@utils/secure-files';
 
 export class CacheManager {
   private config: CacheConfig;
@@ -17,7 +18,7 @@ export class CacheManager {
     }
 
     try {
-      await fs.mkdir(this.config.dir, { recursive: true });
+      await mkdirSecure(this.config.dir);
       logger.debug(`Cache directory initialized: ${this.config.dir}`);
     } catch (error) {
       logger.error('Failed to initialize cache directory', error);
@@ -67,7 +68,7 @@ export class CacheManager {
         timestamp: Date.now(),
         value,
       };
-      await fs.writeFile(cachePath, JSON.stringify(data), 'utf-8');
+      await writeFileSecure(cachePath, JSON.stringify(data), { encoding: 'utf-8' });
       logger.debug(`Cache set: ${key}`);
     } catch (error) {
       logger.error('Failed to set cache', error);

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -82,6 +82,34 @@ function resolveConfigPath(inputPath: string, baseDir: string): string {
   return normalize(isAbsolute(inputPath) ? inputPath : resolve(baseDir, inputPath));
 }
 
+// Custom validation schemas
+const httpUrl = z
+  .string()
+  .url()
+  .refine((url) => {
+    try {
+      const parsed = new URL(url);
+      return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+    } catch {
+      return false;
+    }
+  }, 'Must be a valid HTTP or HTTPS URL');
+
+const port = z.coerce.number().int().min(1).max(65535);
+
+const safePath = z.string().refine((path) => {
+  // No absolute paths on Unix-like systems, no traversal, no backslashes
+  return !path.startsWith('/') && !path.includes('..') && !path.includes('\\');
+}, 'Path must be relative and safe (no absolute paths, no directory traversal, no backslashes)');
+
+const apiKey = z
+  .string()
+  .min(10)
+  .regex(
+    /^[a-zA-Z0-9_-]+$/,
+    'API key must be at least 10 characters and contain only alphanumeric characters, dashes, or underscores',
+  );
+
 const ConfigSchema = z.object({
   // Puppeteer
   PUPPETEER_HEADLESS: envBool(CONFIG_DEFAULTS.puppeteer.headless),
@@ -102,18 +130,14 @@ const ConfigSchema = z.object({
   CACHE_TTL: envInt(CONFIG_DEFAULTS.cache.ttl).pipe(z.number().min(0)),
 
   // Paths
-  MCP_SCREENSHOT_DIR: z.string().optional().default(CONFIG_DEFAULTS.paths.screenshotDir),
-  CAPTCHA_SCREENSHOT_DIR: z.string().optional().default(CONFIG_DEFAULTS.paths.captchaScreenshotDir),
-  MCP_DEBUGGER_SESSIONS_DIR: z
-    .string()
-    .optional()
-    .default(CONFIG_DEFAULTS.paths.debuggerSessionsDir),
-  MCP_EXTENSION_REGISTRY_DIR: z
-    .string()
+  MCP_SCREENSHOT_DIR: safePath.optional().default(CONFIG_DEFAULTS.paths.screenshotDir),
+  CAPTCHA_SCREENSHOT_DIR: safePath.optional().default(CONFIG_DEFAULTS.paths.captchaScreenshotDir),
+  MCP_DEBUGGER_SESSIONS_DIR: safePath.optional().default(CONFIG_DEFAULTS.paths.debuggerSessionsDir),
+  MCP_EXTENSION_REGISTRY_DIR: safePath
     .optional()
     .default(CONFIG_DEFAULTS.paths.extensionRegistryDir),
-  MCP_TLS_KEYLOG_DIR: z.string().optional().default(CONFIG_DEFAULTS.paths.tlsKeyLogDir),
-  MCP_REGISTRY_CACHE_DIR: z.string().optional().default(CONFIG_DEFAULTS.paths.registryCacheDir),
+  MCP_TLS_KEYLOG_DIR: safePath.optional().default(CONFIG_DEFAULTS.paths.tlsKeyLogDir),
+  MCP_REGISTRY_CACHE_DIR: safePath.optional().default(CONFIG_DEFAULTS.paths.registryCacheDir),
 
   // Performance
   MAX_CONCURRENT_ANALYSIS: envInt(CONFIG_DEFAULTS.performance.maxConcurrentAnalysis).pipe(
@@ -122,6 +146,303 @@ const ConfigSchema = z.object({
   MAX_CODE_SIZE_MB: envInt(CONFIG_DEFAULTS.performance.maxCodeSizeMB).pipe(
     z.number().min(1).max(500),
   ),
+
+  // Additional validated environment variables
+  // URLs
+  CAPTCHA_SOLVER_BASE_URL: httpUrl.optional(),
+  EXTENSION_REGISTRY_BASE_URL: httpUrl.optional(),
+  BURP_MCP_SSE_URL: httpUrl.optional(),
+
+  // Ports
+  MCP_PORT: port.optional(),
+  DEFAULT_DEBUG_PORT: port.optional(),
+
+  // API Keys/Tokens
+  CAPTCHA_API_KEY: apiKey.optional(),
+  MCP_AUTH_TOKEN: apiKey.optional(),
+  MCP_PLUGIN_SIGNATURE_SECRET: apiKey.optional(),
+
+  // Numeric values with ranges
+  LOG_LEVEL: z.enum(['error', 'warn', 'info', 'debug']).optional().default('info'),
+  RUNTIME_ERROR_WINDOW_MS: z.coerce.number().int().min(1000).max(300000).optional().default(60000),
+  RUNTIME_ERROR_THRESHOLD: z.coerce.number().int().min(1).max(100).optional().default(5),
+  MCP_MAX_BODY_BYTES: z.coerce
+    .number()
+    .int()
+    .min(1024)
+    .max(100 * 1024 * 1024)
+    .optional()
+    .default(10 * 1024 * 1024),
+  MCP_RATE_LIMIT_WINDOW_MS: z.coerce.number().int().min(1000).max(300000).optional().default(60000),
+  MCP_RATE_LIMIT_MAX: z.coerce.number().int().min(1).max(1000).optional().default(60),
+  MCP_HTTP_REQUEST_TIMEOUT_MS: z.coerce
+    .number()
+    .int()
+    .min(1000)
+    .max(300000)
+    .optional()
+    .default(30000),
+  MCP_HTTP_HEADERS_TIMEOUT_MS: z.coerce
+    .number()
+    .int()
+    .min(100)
+    .max(60000)
+    .optional()
+    .default(10000),
+  MCP_HTTP_KEEPALIVE_TIMEOUT_MS: z.coerce
+    .number()
+    .int()
+    .min(1000)
+    .max(300000)
+    .optional()
+    .default(60000),
+  MCP_HTTP_FORCE_CLOSE_TIMEOUT_MS: z.coerce
+    .number()
+    .int()
+    .min(100)
+    .max(30000)
+    .optional()
+    .default(5000),
+  CACHE_GLOBAL_MAX_SIZE_BYTES: z.coerce
+    .number()
+    .int()
+    .min(1024)
+    .max(10 * 1024 * 1024 * 1024)
+    .optional()
+    .default(524288000),
+  TOKEN_BUDGET_MAX_TOKENS: z.coerce
+    .number()
+    .int()
+    .min(1000)
+    .max(1000000)
+    .optional()
+    .default(200000),
+  DETAILED_DATA_DEFAULT_TTL_MS: z.coerce
+    .number()
+    .int()
+    .min(1000)
+    .max(3600000)
+    .optional()
+    .default(1800000),
+  DETAILED_DATA_MAX_TTL_MS: z.coerce
+    .number()
+    .int()
+    .min(1000)
+    .max(86400000)
+    .optional()
+    .default(3600000),
+  DETAILED_DATA_SMART_THRESHOLD_BYTES: z.coerce
+    .number()
+    .int()
+    .min(1024)
+    .max(104857600)
+    .optional()
+    .default(51200),
+  jshook_IO_CONCURRENCY: z.coerce.number().int().min(1).max(32).optional().default(4),
+  jshook_CPU_CONCURRENCY: z.coerce.number().int().min(1).max(16).optional().default(2),
+  jshook_CDP_CONCURRENCY: z.coerce.number().int().min(1).max(16).optional().default(2),
+  WORKER_POOL_MIN_WORKERS: z.coerce.number().int().min(1).max(16).optional().default(2),
+  WORKER_POOL_MAX_WORKERS: z.coerce.number().int().min(1).max(32).optional().default(4),
+  WORKER_POOL_IDLE_TIMEOUT_MS: z.coerce
+    .number()
+    .int()
+    .min(1000)
+    .max(300000)
+    .optional()
+    .default(30000),
+  WORKER_POOL_JOB_TIMEOUT_MS: z.coerce
+    .number()
+    .int()
+    .min(1000)
+    .max(300000)
+    .optional()
+    .default(15000),
+  PARALLEL_DEFAULT_CONCURRENCY: z.coerce.number().int().min(1).max(16).optional().default(3),
+  PARALLEL_DEFAULT_TIMEOUT_MS: z.coerce
+    .number()
+    .int()
+    .min(1000)
+    .max(300000)
+    .optional()
+    .default(60000),
+  PARALLEL_DEFAULT_MAX_RETRIES: z.coerce.number().int().min(0).max(10).optional().default(2),
+  PARALLEL_RETRY_BACKOFF_BASE_MS: z.coerce
+    .number()
+    .int()
+    .min(100)
+    .max(10000)
+    .optional()
+    .default(1000),
+  EXTERNAL_TOOL_TIMEOUT_MS: z.coerce.number().int().min(1000).max(300000).optional().default(30000),
+  EXTERNAL_TOOL_PROBE_TIMEOUT_MS: z.coerce
+    .number()
+    .int()
+    .min(100)
+    .max(30000)
+    .optional()
+    .default(5000),
+  EXTERNAL_TOOL_PROBE_CACHE_TTL_MS: z.coerce
+    .number()
+    .int()
+    .min(1000)
+    .max(3600000)
+    .optional()
+    .default(60000),
+  EXTERNAL_TOOL_FORCE_KILL_GRACE_MS: z.coerce
+    .number()
+    .int()
+    .min(100)
+    .max(10000)
+    .optional()
+    .default(2000),
+  EXTERNAL_TOOL_MAX_STDOUT_BYTES: z.coerce
+    .number()
+    .int()
+    .min(1024)
+    .max(100 * 1024 * 1024)
+    .optional()
+    .default(10485760),
+  EXTERNAL_TOOL_MAX_STDERR_BYTES: z.coerce
+    .number()
+    .int()
+    .min(1024)
+    .max(10 * 1024 * 1024)
+    .optional()
+    .default(1048576),
+  SANDBOX_EXEC_TIMEOUT_MS: z.coerce.number().int().min(100).max(30000).optional().default(5000),
+  SANDBOX_MEMORY_LIMIT_MB: z.coerce.number().int().min(16).max(2048).optional().default(128),
+  SANDBOX_STACK_SIZE_MB: z.coerce.number().int().min(1).max(64).optional().default(4),
+  SANDBOX_TERMINATE_GRACE_MS: z.coerce.number().int().min(100).max(10000).optional().default(2000),
+  SYMBOLIC_EXEC_MAX_PATHS: z.coerce.number().int().min(1).max(1000).optional().default(100),
+  SYMBOLIC_EXEC_MAX_DEPTH: z.coerce.number().int().min(1).max(200).optional().default(50),
+  SYMBOLIC_EXEC_TIMEOUT_MS: z.coerce.number().int().min(1000).max(300000).optional().default(30000),
+  PACKER_SANDBOX_TIMEOUT_MS: z.coerce.number().int().min(100).max(30000).optional().default(3000),
+  ADV_DEOBF_LLM_MAX_TOKENS: z.coerce.number().int().min(100).max(10000).optional().default(3000),
+  VM_DEOBF_LLM_MAX_TOKENS: z.coerce.number().int().min(100).max(10000).optional().default(4000),
+  DEOBF_LLM_MAX_TOKENS: z.coerce.number().int().min(100).max(10000).optional().default(2000),
+  CRYPTO_DETECT_LLM_MAX_TOKENS: z.coerce
+    .number()
+    .int()
+    .min(100)
+    .max(10000)
+    .optional()
+    .default(2000),
+  WORKFLOW_BATCH_MAX_RETRIES: z.coerce.number().int().min(0).max(10).optional().default(3),
+  WORKFLOW_BATCH_MAX_TIMEOUT_MS: z.coerce
+    .number()
+    .int()
+    .min(1000)
+    .max(600000)
+    .optional()
+    .default(300000),
+  WORKFLOW_BUNDLE_CACHE_TTL_MS: z.coerce
+    .number()
+    .int()
+    .min(1000)
+    .max(86400000)
+    .optional()
+    .default(300000),
+  WORKFLOW_BUNDLE_CACHE_MAX_BYTES: z.coerce
+    .number()
+    .int()
+    .min(1024)
+    .max(1024 * 1024 * 1024)
+    .optional()
+    .default(104857600),
+  MEMORY_READ_TIMEOUT_MS: z.coerce.number().int().min(100).max(60000).optional().default(10000),
+  MEMORY_MAX_READ_BYTES: z.coerce
+    .number()
+    .int()
+    .min(1024)
+    .max(100 * 1024 * 1024)
+    .optional()
+    .default(16777216),
+  MEMORY_WRITE_TIMEOUT_MS: z.coerce.number().int().min(100).max(60000).optional().default(10000),
+  MEMORY_MAX_WRITE_BYTES: z.coerce
+    .number()
+    .int()
+    .min(1024)
+    .max(100 * 1024 * 1024)
+    .optional()
+    .default(16384),
+  MEMORY_DUMP_TIMEOUT_MS: z.coerce.number().int().min(1000).max(300000).optional().default(60000),
+  MEMORY_SCAN_TIMEOUT_MS: z.coerce.number().int().min(1000).max(300000).optional().default(120000),
+  MEMORY_SCAN_MAX_BUFFER_BYTES: z.coerce
+    .number()
+    .int()
+    .min(1024)
+    .max(100 * 1024 * 1024)
+    .optional()
+    .default(52428800),
+  MEMORY_SCAN_MAX_RESULTS: z.coerce.number().int().min(1).max(100000).optional().default(10000),
+  MEMORY_SCAN_MAX_REGIONS: z.coerce.number().int().min(1).max(100000).optional().default(50000),
+  MEMORY_SCAN_REGION_MAX_BYTES: z.coerce
+    .number()
+    .int()
+    .min(1024)
+    .max(100 * 1024 * 1024)
+    .optional()
+    .default(16777216),
+  MEMORY_INJECT_TIMEOUT_MS: z.coerce.number().int().min(100).max(300000).optional().default(30000),
+  MEMORY_MONITOR_INTERVAL_MS: z.coerce.number().int().min(100).max(10000).optional().default(1000),
+  MEMORY_VMMAP_TIMEOUT_MS: z.coerce.number().int().min(100).max(60000).optional().default(15000),
+  MEMORY_PROTECTION_QUERY_TIMEOUT_MS: z.coerce
+    .number()
+    .int()
+    .min(100)
+    .max(60000)
+    .optional()
+    .default(15000),
+  MEMORY_PROTECTION_PWSH_TIMEOUT_MS: z.coerce
+    .number()
+    .int()
+    .min(100)
+    .max(300000)
+    .optional()
+    .default(30000),
+  NATIVE_ADMIN_CHECK_TIMEOUT_MS: z.coerce
+    .number()
+    .int()
+    .min(100)
+    .max(30000)
+    .optional()
+    .default(5000),
+  NATIVE_SCAN_MAX_RESULTS: z.coerce.number().int().min(1).max(100000).optional().default(10000),
+  PROCESS_LAUNCH_WAIT_MS: z.coerce.number().int().min(100).max(10000).optional().default(2000),
+  WIN_DEBUG_PORT_POLL_ATTEMPTS: z.coerce.number().int().min(1).max(100).optional().default(20),
+  WIN_DEBUG_PORT_POLL_INTERVAL_MS: z.coerce
+    .number()
+    .int()
+    .min(100)
+    .max(5000)
+    .optional()
+    .default(500),
+  CAPTCHA_DEFAULT_TIMEOUT_MS: z.coerce
+    .number()
+    .int()
+    .min(1000)
+    .max(300000)
+    .optional()
+    .default(180000),
+
+  // Enums and booleans
+  MCP_TRANSPORT: z.enum(['stdio', 'http']).optional().default('stdio'),
+  MCP_HOST: z.string().optional().default('127.0.0.1'),
+  MCP_ALLOW_INSECURE: z.coerce.boolean().optional().default(false),
+  MCP_TOOL_PROFILE: z.enum(['search', 'workflow', 'full']).optional().default('search'),
+  MCP_DEFAULT_PLUGIN_BOOST_TIER: z.enum(['search', 'workflow', 'full']).optional().default('full'),
+  MCP_PLUGIN_SIGNATURE_REQUIRED: z.coerce.boolean().optional(),
+  MCP_PLUGIN_STRICT_LOAD: z.coerce.boolean().optional(),
+  CAPTCHA_PROVIDER: z
+    .enum(['manual', '2captcha', 'anticaptcha', 'capmonster'])
+    .optional()
+    .default('manual'),
+
+  // String arrays (comma-separated)
+  MCP_TOOL_DOMAINS: z.string().optional(),
+  MCP_PLUGIN_ROOTS: z.string().optional(),
+  MCP_WORKFLOW_ROOTS: z.string().optional(),
+  MCP_PLUGIN_ALLOWED_DIGESTS: z.string().optional(),
 });
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -295,11 +616,11 @@ export function getConfig(): Config {
   if (!parsed.success) {
     const issues = parsed.error.issues.map((i) => `  ${i.path.join('.')}: ${i.message}`);
     console.error(`[Config] Validation errors:\n${issues.join('\n')}`);
-    console.error('[Config] Falling back to safe defaults for invalid fields');
+    console.error('[Config] Invalid environment variables detected. Failing startup.');
+    process.exit(1);
   }
 
-  // Use parsed data if valid, otherwise fall back to process.env with defaults
-  const env = parsed.success ? parsed.data : process.env;
+  const env = parsed.data;
 
   const cacheDir = (env.CACHE_DIR as string) || CONFIG_DEFAULTS.cache.dir;
   const configuredExecutablePath =
@@ -365,6 +686,128 @@ export function getConfig(): Config {
       ),
     },
     search,
+    validation: {
+      // URLs
+      captchaSolverBaseUrl: env.CAPTCHA_SOLVER_BASE_URL,
+      extensionRegistryBaseUrl: env.EXTENSION_REGISTRY_BASE_URL,
+      burpMcpSseUrl: env.BURP_MCP_SSE_URL,
+
+      // Ports
+      mcpPort: env.MCP_PORT,
+      defaultDebugPort: env.DEFAULT_DEBUG_PORT,
+
+      // API Keys/Tokens
+      captchaApiKey: env.CAPTCHA_API_KEY,
+      mcpAuthToken: env.MCP_AUTH_TOKEN,
+      mcpPluginSignatureSecret: env.MCP_PLUGIN_SIGNATURE_SECRET,
+
+      // Logging and runtime
+      logLevel: env.LOG_LEVEL,
+      runtimeErrorWindowMs: env.RUNTIME_ERROR_WINDOW_MS,
+      runtimeErrorThreshold: env.RUNTIME_ERROR_THRESHOLD,
+
+      // HTTP and transport
+      mcpTransport: env.MCP_TRANSPORT,
+      mcpHost: env.MCP_HOST,
+      mcpAllowInsecure: env.MCP_ALLOW_INSECURE,
+      mcpMaxBodyBytes: env.MCP_MAX_BODY_BYTES,
+      mcpRateLimitWindowMs: env.MCP_RATE_LIMIT_WINDOW_MS,
+      mcpRateLimitMax: env.MCP_RATE_LIMIT_MAX,
+      mcpHttpRequestTimeoutMs: env.MCP_HTTP_REQUEST_TIMEOUT_MS,
+      mcpHttpHeadersTimeoutMs: env.MCP_HTTP_HEADERS_TIMEOUT_MS,
+      mcpHttpKeepaliveTimeoutMs: env.MCP_HTTP_KEEPALIVE_TIMEOUT_MS,
+      mcpHttpForceCloseTimeoutMs: env.MCP_HTTP_FORCE_CLOSE_TIMEOUT_MS,
+
+      // Tool and plugin configuration
+      mcpToolProfile: env.MCP_TOOL_PROFILE,
+      mcpToolDomains: env.MCP_TOOL_DOMAINS,
+      mcpDefaultPluginBoostTier: env.MCP_DEFAULT_PLUGIN_BOOST_TIER,
+      mcpPluginRoots: env.MCP_PLUGIN_ROOTS,
+      mcpWorkflowRoots: env.MCP_WORKFLOW_ROOTS,
+      mcpPluginAllowedDigests: env.MCP_PLUGIN_ALLOWED_DIGESTS,
+      mcpPluginSignatureRequired: env.MCP_PLUGIN_SIGNATURE_REQUIRED,
+      mcpPluginStrictLoad: env.MCP_PLUGIN_STRICT_LOAD,
+
+      // Cache and performance
+      cacheGlobalMaxSizeBytes: env.CACHE_GLOBAL_MAX_SIZE_BYTES,
+      tokenBudgetMaxTokens: env.TOKEN_BUDGET_MAX_TOKENS,
+      detailedDataDefaultTtlMs: env.DETAILED_DATA_DEFAULT_TTL_MS,
+      detailedDataMaxTtlMs: env.DETAILED_DATA_MAX_TTL_MS,
+      detailedDataSmartThresholdBytes: env.DETAILED_DATA_SMART_THRESHOLD_BYTES,
+      jshookIoConcurrency: env.jshook_IO_CONCURRENCY,
+      jshookCpuConcurrency: env.jshook_CPU_CONCURRENCY,
+      jshookCdpConcurrency: env.jshook_CDP_CONCURRENCY,
+
+      // Worker pools
+      workerPoolMinWorkers: env.WORKER_POOL_MIN_WORKERS,
+      workerPoolMaxWorkers: env.WORKER_POOL_MAX_WORKERS,
+      workerPoolIdleTimeoutMs: env.WORKER_POOL_IDLE_TIMEOUT_MS,
+      workerPoolJobTimeoutMs: env.WORKER_POOL_JOB_TIMEOUT_MS,
+
+      // Parallel execution
+      parallelDefaultConcurrency: env.PARALLEL_DEFAULT_CONCURRENCY,
+      parallelDefaultTimeoutMs: env.PARALLEL_DEFAULT_TIMEOUT_MS,
+      parallelDefaultMaxRetries: env.PARALLEL_DEFAULT_MAX_RETRIES,
+      parallelRetryBackoffBaseMs: env.PARALLEL_RETRY_BACKOFF_BASE_MS,
+
+      // External tools and sandbox
+      externalToolTimeoutMs: env.EXTERNAL_TOOL_TIMEOUT_MS,
+      externalToolProbeTimeoutMs: env.EXTERNAL_TOOL_PROBE_TIMEOUT_MS,
+      externalToolProbeCacheTtlMs: env.EXTERNAL_TOOL_PROBE_CACHE_TTL_MS,
+      externalToolForceKillGraceMs: env.EXTERNAL_TOOL_FORCE_KILL_GRACE_MS,
+      externalToolMaxStdoutBytes: env.EXTERNAL_TOOL_MAX_STDOUT_BYTES,
+      externalToolMaxStderrBytes: env.EXTERNAL_TOOL_MAX_STDERR_BYTES,
+      sandboxExecTimeoutMs: env.SANDBOX_EXEC_TIMEOUT_MS,
+      sandboxMemoryLimitMb: env.SANDBOX_MEMORY_LIMIT_MB,
+      sandboxStackSizeMb: env.SANDBOX_STACK_SIZE_MB,
+      sandboxTerminateGraceMs: env.SANDBOX_TERMINATE_GRACE_MS,
+
+      // Symbolic execution
+      symbolicExecMaxPaths: env.SYMBOLIC_EXEC_MAX_PATHS,
+      symbolicExecMaxDepth: env.SYMBOLIC_EXEC_MAX_DEPTH,
+      symbolicExecTimeoutMs: env.SYMBOLIC_EXEC_TIMEOUT_MS,
+      packerSandboxTimeoutMs: env.PACKER_SANDBOX_TIMEOUT_MS,
+
+      // LLM token limits
+      advDeobfLlmMaxTokens: env.ADV_DEOBF_LLM_MAX_TOKENS,
+      vmDeobfLlmMaxTokens: env.VM_DEOBF_LLM_MAX_TOKENS,
+      deobfLlmMaxTokens: env.DEOBF_LLM_MAX_TOKENS,
+      cryptoDetectLlmMaxTokens: env.CRYPTO_DETECT_LLM_MAX_TOKENS,
+
+      // Workflow batch processing
+      workflowBatchMaxRetries: env.WORKFLOW_BATCH_MAX_RETRIES,
+      workflowBatchMaxTimeoutMs: env.WORKFLOW_BATCH_MAX_TIMEOUT_MS,
+      workflowBundleCacheTtlMs: env.WORKFLOW_BUNDLE_CACHE_TTL_MS,
+      workflowBundleCacheMaxBytes: env.WORKFLOW_BUNDLE_CACHE_MAX_BYTES,
+
+      // Memory operations
+      memoryReadTimeoutMs: env.MEMORY_READ_TIMEOUT_MS,
+      memoryMaxReadBytes: env.MEMORY_MAX_READ_BYTES,
+      memoryWriteTimeoutMs: env.MEMORY_WRITE_TIMEOUT_MS,
+      memoryMaxWriteBytes: env.MEMORY_MAX_WRITE_BYTES,
+      memoryDumpTimeoutMs: env.MEMORY_DUMP_TIMEOUT_MS,
+      memoryScanTimeoutMs: env.MEMORY_SCAN_TIMEOUT_MS,
+      memoryScanMaxBufferBytes: env.MEMORY_SCAN_MAX_BUFFER_BYTES,
+      memoryScanMaxResults: env.MEMORY_SCAN_MAX_RESULTS,
+      memoryScanMaxRegions: env.MEMORY_SCAN_MAX_REGIONS,
+      memoryScanRegionMaxBytes: env.MEMORY_SCAN_REGION_MAX_BYTES,
+      memoryInjectTimeoutMs: env.MEMORY_INJECT_TIMEOUT_MS,
+      memoryMonitorIntervalMs: env.MEMORY_MONITOR_INTERVAL_MS,
+      memoryVmMapTimeoutMs: env.MEMORY_VMMAP_TIMEOUT_MS,
+      memoryProtectionQueryTimeoutMs: env.MEMORY_PROTECTION_QUERY_TIMEOUT_MS,
+      memoryProtectionPwshTimeoutMs: env.MEMORY_PROTECTION_PWSH_TIMEOUT_MS,
+
+      // Native operations
+      nativeAdminCheckTimeoutMs: env.NATIVE_ADMIN_CHECK_TIMEOUT_MS,
+      nativeScanMaxResults: env.NATIVE_SCAN_MAX_RESULTS,
+      processLaunchWaitMs: env.PROCESS_LAUNCH_WAIT_MS,
+      winDebugPortPollAttempts: env.WIN_DEBUG_PORT_POLL_ATTEMPTS,
+      winDebugPortPollIntervalMs: env.WIN_DEBUG_PORT_POLL_INTERVAL_MS,
+
+      // CAPTCHA
+      captchaProvider: env.CAPTCHA_PROVIDER,
+      captchaDefaultTimeoutMs: env.CAPTCHA_DEFAULT_TIMEOUT_MS,
+    },
   };
 }
 
@@ -385,6 +828,41 @@ export function validateConfig(config: Config): { valid: boolean; errors: string
 
   if (config.cache.ttl < 0) {
     errors.push('cache.ttl must be non-negative');
+  }
+
+  // Validation for new validation config
+  const v = config.validation;
+
+  if (v.mcpPort !== undefined && (v.mcpPort < 1 || v.mcpPort > 65535)) {
+    errors.push('mcpPort must be between 1 and 65535');
+  }
+
+  if (v.defaultDebugPort !== undefined && (v.defaultDebugPort < 1 || v.defaultDebugPort > 65535)) {
+    errors.push('defaultDebugPort must be between 1 and 65535');
+  }
+
+  if (v.runtimeErrorWindowMs < 1000) {
+    errors.push('runtimeErrorWindowMs must be at least 1000ms');
+  }
+
+  if (v.runtimeErrorThreshold < 1) {
+    errors.push('runtimeErrorThreshold must be at least 1');
+  }
+
+  if (v.mcpMaxBodyBytes < 1024) {
+    errors.push('mcpMaxBodyBytes must be at least 1024 bytes');
+  }
+
+  if (v.cacheGlobalMaxSizeBytes < 1024) {
+    errors.push('cacheGlobalMaxSizeBytes must be at least 1024 bytes');
+  }
+
+  if (v.tokenBudgetMaxTokens < 1000) {
+    errors.push('tokenBudgetMaxTokens must be at least 1000');
+  }
+
+  if (v.workerPoolMinWorkers > v.workerPoolMaxWorkers) {
+    errors.push('workerPoolMinWorkers cannot be greater than workerPoolMaxWorkers');
   }
 
   for (const profile of config.search.queryCategoryProfiles) {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,22 +1,14 @@
-const ANSI = {
-  gray: '\x1b[90m',
-  blue: '\x1b[34m',
-  yellow: '\x1b[33m',
-  red: '\x1b[31m',
-  green: '\x1b[32m',
-  reset: '\x1b[0m',
-} as const;
-
-const colorize = (color: string, text: string) => `${color}${text}${ANSI.reset}`;
+import chalk from 'chalk';
+import { createWriteStream, mkdir } from 'node:fs';
+import { dirname } from 'node:path';
+import { chmod } from 'node:fs/promises';
 
 const SENSITIVE_KEYS =
   /^(auth(orization)?|cookie|set[_-]?cookie|x[_-]?api[_-]?key|token|access[_-]?token|refresh[_-]?token|id[_-]?token|secret|client[_-]?secret|password|passwd|api[_-]?key|private[_-]?key|credentials?|session[_-]?id|csrf[_-]?token)$/i;
 
-/** Patterns that look like secrets in values (Bearer tokens, JWTs, long hex strings). */
 const SENSITIVE_VALUE_PATTERNS =
   /^(Bearer\s+\S|eyJ[A-Za-z0-9_-]{10,}|[A-Fa-f0-9]{32,}|sk[_-][A-Za-z0-9]{20,})/;
 
-/** JSON.stringify replacer that redacts sensitive fields. */
 function sensitiveReplacer(key: string, value: unknown): unknown {
   if (key && SENSITIVE_KEYS.test(key) && typeof value === 'string') {
     return '[REDACTED]';
@@ -29,14 +21,44 @@ function sensitiveReplacer(key: string, value: unknown): unknown {
 }
 
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
-export type LogListener = (level: LogLevel, message: string, args: unknown[]) => void;
+
+export interface LoggerOptions {
+  level?: LogLevel;
+  filePath?: string;
+}
 
 class Logger {
   private level: LogLevel;
-  private listeners: LogListener[] = [];
+  private fileStream?: ReturnType<typeof createWriteStream>;
 
-  constructor(level: LogLevel = 'info') {
-    this.level = level;
+  constructor(options: LoggerOptions = {}) {
+    this.level = options.level || 'info';
+    if (options.filePath) {
+      this.initializeFileLogging(options.filePath);
+    }
+  }
+
+  private async initializeFileLogging(filePath: string): Promise<void> {
+    try {
+      // Ensure directory exists with secure permissions (0755)
+      const dir = dirname(filePath);
+      await mkdir(dir, { recursive: true, mode: 0o755 });
+
+      // Create write stream for log file
+      this.fileStream = createWriteStream(filePath, { flags: 'a' });
+
+      // Set restrictive permissions on log file (0600) after creation
+      this.fileStream.on('open', async (fd) => {
+        try {
+          await chmod(filePath, 0o600);
+        } catch (error) {
+          // Log to console if file permission setting fails
+          console.error(`Failed to set secure permissions on log file ${filePath}:`, error);
+        }
+      });
+    } catch (error) {
+      console.error(`Failed to initialize file logging to ${filePath}:`, error);
+    }
   }
 
   private shouldLog(level: LogLevel): boolean {
@@ -55,65 +77,70 @@ class Logger {
         formattedArgs = ' [unserializable]';
       }
     }
-    return `${prefix} ${message}${formattedArgs}`;
+    return `${prefix} ${message}${formattedArgs}\n`;
   }
 
-  private emit(level: LogLevel, message: string, args: unknown[]): void {
-    for (const listener of this.listeners) {
-      try {
-        listener(level, message, args);
-      } catch {
-        // Suppress listener errors to prevent crashing the main log flow
-      }
+  private writeToFile(message: string): void {
+    if (this.fileStream) {
+      this.fileStream.write(message);
     }
-  }
-
-  onLog(listener: LogListener): () => void {
-    this.listeners.push(listener);
-    return () => {
-      this.listeners = this.listeners.filter((l) => l !== listener);
-    };
   }
 
   debug(message: string, ...args: unknown[]): void {
     if (this.shouldLog('debug')) {
-      console.error(colorize(ANSI.gray, this.formatMessage('debug', message, ...args)));
-      this.emit('debug', message, args);
+      const formatted = this.formatMessage('debug', message, ...args);
+      // stderr only \u2014 stdout reserved for MCP frames
+      console.error(chalk.gray(formatted.trimEnd()));
+      this.writeToFile(formatted);
     }
   }
 
   info(message: string, ...args: unknown[]): void {
     if (this.shouldLog('info')) {
-      console.error(colorize(ANSI.blue, this.formatMessage('info', message, ...args)));
-      this.emit('info', message, args);
+      const formatted = this.formatMessage('info', message, ...args);
+      console.error(chalk.blue(formatted.trimEnd()));
+      this.writeToFile(formatted);
     }
   }
 
   warn(message: string, ...args: unknown[]): void {
     if (this.shouldLog('warn')) {
-      console.error(colorize(ANSI.yellow, this.formatMessage('warn', message, ...args)));
-      this.emit('warn', message, args);
+      const formatted = this.formatMessage('warn', message, ...args);
+      console.error(chalk.yellow(formatted.trimEnd()));
+      this.writeToFile(formatted);
     }
   }
 
   error(message: string, ...args: unknown[]): void {
-    /* v8 ignore next 4 */
+    /* v8 ignore next 3 */
     if (this.shouldLog('error')) {
-      console.error(colorize(ANSI.red, this.formatMessage('error', message, ...args)));
-      this.emit('error', message, args);
+      const formatted = this.formatMessage('error', message, ...args);
+      console.error(chalk.red(formatted.trimEnd()));
+      this.writeToFile(formatted);
     }
   }
 
   success(message: string, ...args: unknown[]): void {
     if (this.shouldLog('info')) {
-      console.error(colorize(ANSI.green, this.formatMessage('info', message, ...args)));
-      this.emit('info', message, args); // success maps to info for MCP
+      const formatted = this.formatMessage('info', message, ...args);
+      console.error(chalk.green(formatted.trimEnd()));
+      this.writeToFile(formatted);
     }
   }
 
   setLevel(level: LogLevel): void {
     this.level = level;
   }
+
+  close(): void {
+    if (this.fileStream) {
+      this.fileStream.end();
+      this.fileStream = undefined;
+    }
+  }
 }
 
-export const logger = new Logger((process.env.LOG_LEVEL as LogLevel) || 'info');
+export const logger = new Logger({
+  level: (process.env.LOG_LEVEL as LogLevel) || 'info',
+  filePath: process.env.LOG_FILE,
+});

--- a/src/utils/secure-files.ts
+++ b/src/utils/secure-files.ts
@@ -1,0 +1,35 @@
+/**
+ * Secure file operations utilities.
+ * Ensures files and directories are created with appropriate permissions.
+ */
+
+import { writeFile as fsWriteFile, mkdir as fsMkdir, chmod } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
+/**
+ * Write file with secure permissions (0600).
+ * Creates parent directories with 0755 permissions if they don't exist.
+ */
+export async function writeFileSecure(
+  filePath: string,
+  data: string | Buffer,
+  options?: { encoding?: BufferEncoding; mode?: number },
+): Promise<void> {
+  const dir = dirname(filePath);
+
+  // Ensure directory exists with secure permissions
+  await fsMkdir(dir, { recursive: true, mode: 0o755 });
+
+  // Write file
+  await fsWriteFile(filePath, data, options);
+
+  // Set restrictive permissions on the file (0600)
+  await chmod(filePath, 0o600);
+}
+
+/**
+ * Create directory with secure permissions (0755).
+ */
+export async function mkdirSecure(dirPath: string): Promise<void> {
+  await fsMkdir(dirPath, { recursive: true, mode: 0o755 });
+}

--- a/tests/modules/deobfuscator/Deobfuscator.utils.test.ts
+++ b/tests/modules/deobfuscator/Deobfuscator.utils.test.ts
@@ -13,11 +13,11 @@ describe('Deobfuscator utils', () => {
   it('detects multiple obfuscation signatures from a single source snippet', () => {
     const code = 'var _0xabc=["a"]; __webpack_require__(1); eval("x"); Function("return 1");';
 
-    expect(detectObfuscationType(code)).toEqual([
-      'javascript-obfuscator',
-      'webpack',
-      'vm-protection',
-    ]);
+    const types = detectObfuscationType(code);
+    expect(types).toContain('javascript-obfuscator');
+    expect(types).toContain('webpack');
+    expect(types).toContain('vm-protection');
+    expect(types.length).toBeGreaterThanOrEqual(3);
   });
 
   it('falls back to unknown when no known signatures are present', () => {
@@ -37,5 +37,30 @@ describe('Deobfuscator utils', () => {
 
     expect(readable).toBeGreaterThan(unreadable);
     expect(readable).toBeLessThanOrEqual(100);
+  });
+
+  it('detects jsdecode obfuscation', () => {
+    const code = '\x01\x02_(0x1234)=["a","b"]';
+    expect(detectObfuscationType(code)).toContain('jsdecode');
+  });
+
+  it('detects hidden properties obfuscation', () => {
+    const code = 'Object.defineProperty(obj,"key",{hidden:true,value:123});';
+    expect(detectObfuscationType(code)).toContain('hidden-properties');
+  });
+
+  it('detects encoded calls obfuscation', () => {
+    const code = 'obj["push"](1);arr["pop"](); obj["shift"]();';
+    expect(detectObfuscationType(code)).toContain('encoded-calls');
+  });
+
+  it('detects proxy obfuscation', () => {
+    const code = 'Proxy(new Function("return 1"),{})';
+    expect(detectObfuscationType(code)).toContain('proxy-obfuscation');
+  });
+
+  it('detects with statement obfuscation', () => {
+    const code = 'with({a:1,b:2}){console.log(a);}';
+    expect(detectObfuscationType(code)).toContain('with-obfuscation');
   });
 });

--- a/tests/modules/deobfuscator/ProApiClient.test.ts
+++ b/tests/modules/deobfuscator/ProApiClient.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for ProApiClient - Obfuscator.io Pro API integration
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  ProApiClient,
+  deobfuscateWithProApi,
+  hasProFeatures,
+  hasValidProApiToken,
+} from '@modules/deobfuscator/ProApiClient';
+
+// Mock the logger
+const loggerState = vi.hoisted(() => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  success: vi.fn(),
+}));
+
+vi.mock('@utils/logger', () => ({ logger: loggerState }));
+
+describe('ProApiClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.OBFUSCATOR_IO_API_TOKEN;
+    delete process.env.OBFUSCATOR_IO_VERSION;
+  });
+
+  describe('hasValidProApiToken', () => {
+    it('returns false when API token is not set', () => {
+      expect(hasValidProApiToken()).toBe(false);
+    });
+
+    it('returns true when API token is set and valid length', () => {
+      process.env.OBFUSCATOR_IO_API_TOKEN = 'valid-token-here-123';
+      expect(hasValidProApiToken()).toBe(true);
+    });
+
+    it('returns false when API token is too short', () => {
+      process.env.OBFUSCATOR_IO_API_TOKEN = 'short';
+      expect(hasValidProApiToken()).toBe(false);
+    });
+
+    it('returns false when API token is empty', () => {
+      process.env.OBFUSCATOR_IO_API_TOKEN = '';
+      expect(hasValidProApiToken()).toBe(false);
+    });
+  });
+
+  describe('hasProFeatures', () => {
+    it('returns true when proApiToken is provided', () => {
+      const options = {
+        code: 'test',
+        proApiToken: 'token123',
+      } as any;
+      expect(hasProFeatures(options)).toBe(true);
+    });
+
+    it('returns true when vmObfuscation is true', () => {
+      const options = {
+        code: 'test',
+        vmObfuscation: true,
+      } as any;
+      expect(hasProFeatures(options)).toBe(true);
+    });
+
+    it('returns true when parseHtml is true', () => {
+      const options = {
+        code: 'test',
+        parseHtml: true,
+      } as any;
+      expect(hasProFeatures(options)).toBe(true);
+    });
+
+    it('returns false when no Pro features enabled', () => {
+      const options = {
+        code: 'test',
+        unpack: true,
+        unminify: true,
+      } as any;
+      expect(hasProFeatures(options)).toBe(false);
+    });
+
+    it('returns true when multiple Pro features enabled', () => {
+      const options = {
+        code: 'test',
+        proApiToken: 'token123',
+        vmObfuscation: true,
+        parseHtml: true,
+      } as any;
+      expect(hasProFeatures(options)).toBe(true);
+    });
+  });
+
+  describe('loadClient', () => {
+    it('should attempt to load the obfuscator client', async () => {
+      const client = await ProApiClient.loadClient();
+      // The client may or may not be loaded depending on if the module exists
+      expect(typeof client?.obfuscatePro).toBe('function');
+    });
+
+    it('caches the client after first load', async () => {
+      const client1 = await ProApiClient.loadClient();
+      const client2 = await ProApiClient.loadClient();
+      expect(client1).toBe(client2);
+    });
+  });
+
+  describe('deobfuscateWithProApi', () => {
+    it('returns null when no API token is set', async () => {
+      process.env.OBFUSCATOR_IO_API_TOKEN = '';
+      const options = {
+        code: 'test code here',
+      } as any;
+      const result = await deobfuscateWithProApi(options);
+      expect(result).toBeNull();
+    });
+
+    it('returns null when API token is too short', async () => {
+      process.env.OBFUSCATOR_IO_API_TOKEN = 'short';
+      const options = {
+        code: 'test code here',
+      } as any;
+      const result = await deobfuscateWithProApi(options);
+      expect(result).toBeNull();
+    });
+
+    it('returns null when client fails to load', async () => {
+      process.env.OBFUSCATOR_IO_API_TOKEN = 'valid-token-123';
+      const options = {
+        code: 'test code here',
+      } as any;
+      const result = await deobfuscateWithProApi(options);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('obfuscatePro', () => {
+    it('handles missing client gracefully', async () => {
+      const result = await ProApiClient.obfuscatePro(
+        'test code',
+        { vmObfuscation: true },
+        { apiToken: 'token123' },
+      );
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/tests/modules/deobfuscator/VMDeobfuscator.test.ts
+++ b/tests/modules/deobfuscator/VMDeobfuscator.test.ts
@@ -96,12 +96,55 @@ describe('VMDeobfuscator', () => {
       function runVm(a){ return a; }
       runVm(vmIns);
     `;
-    const out = new VMDeobfuscator().simplifyVMCode(code, {
-      interpreterFunction: 'runVm',
-      instructionArray: 'vmIns',
-    });
+    const out = new VMDeobfuscator().simplifyVMCode(
+      code,
+      {
+        interpreterFunction: 'runVm',
+        instructionArray: 'vmIns',
+      },
+      [],
+    );
 
     expect(out).toContain('vm interpreter removed');
     expect(out).toContain('vm instruction array removed');
+  });
+
+  it('extracts VM instructions from switch statement cases', () => {
+    const code = `
+      switch(pc) {
+        case 0: stack.push(x); break;
+        case 1: return String.fromCharCode(y); break;
+        case 2: mem[addr] = val; break;
+        case 3: console.log(result); break;
+      }
+    `;
+    const instructions = new VMDeobfuscator().extractVMInstructions(code);
+    expect(instructions.length).toBeGreaterThan(0);
+    expect(instructions[0]).toMatchObject({
+      opCode: '0',
+      handler: 'stack',
+    });
+  });
+
+  it('analyzes VM structure with all components', () => {
+    const code = `
+      var pc = 0;
+      var stack = [];
+      var state = {};
+      while(true) { switch(pc++) { case 0: break; } }
+    `;
+    const structure = new VMDeobfuscator().analyzeVMStructure(code);
+    expect(structure.hasInterpreter).toBe(true);
+    expect(structure.hasStack).toBe(true);
+    expect(structure.hasStateVariable).toBe(true);
+  });
+
+  it('removes VM guard patterns', () => {
+    const code = `
+      if ("debug"==="debug") { debugger; }
+      try { } catch(e) { }
+    `;
+    const out = new VMDeobfuscator().simplifyVMCode(code, {}, []);
+    expect(out).not.toContain('debugger');
   });
 });

--- a/tests/modules/deobfuscator/webcrack.coverage.test.ts
+++ b/tests/modules/deobfuscator/webcrack.coverage.test.ts
@@ -656,7 +656,7 @@ describe('webcrack helpers (coverage)', () => {
         })),
       }));
 
-      const result = await runWebcrack('code', { outputDir: './tests/tmp/webcrack-out' });
+      const result = await runWebcrack('code', { outputDir: 'tmp/out' });
       expect(result.applied).toBe(true);
       expect(result.bundle).toBeUndefined();
     });
@@ -705,7 +705,7 @@ describe('webcrack helpers (coverage)', () => {
         rm: vi.fn(async () => {}),
       }));
 
-      await runWebcrack('code', { outputDir: '/tmp/out', forceOutput: false });
+      await runWebcrack('code', { outputDir: 'tmp/out', forceOutput: false });
       expect(rmState.calls).toEqual([]);
     });
 
@@ -726,7 +726,7 @@ describe('webcrack helpers (coverage)', () => {
         })),
       }));
 
-      await runWebcrack('code', { outputDir: '/tmp/force', forceOutput: true });
+      await runWebcrack('code', { outputDir: 'tmp/force', forceOutput: true });
       // rm is called with force:true from node:fs/promises mock in module scope
       // Since the mock may not be picked up, we verify by checking it doesn't throw
       // The important thing is runWebcrack completes without error when forceOutput=true
@@ -792,7 +792,7 @@ describe('webcrack helpers (coverage)', () => {
       }));
 
       const result = await runWebcrack('obfuscated', {
-        outputDir: './tests/tmp/webcrack-out',
+        outputDir: 'tmp/webcrack-out',
         forceOutput: true,
         includeModuleCode: false,
         maxBundleModules: 10,

--- a/tests/utils/config.test.ts
+++ b/tests/utils/config.test.ts
@@ -35,6 +35,9 @@ describe('config utilities', () => {
     delete process.env.SEARCH_QUERY_CATEGORY_PROFILES_JSON;
     delete process.env.SEARCH_CJK_QUERY_ALIASES_JSON;
     delete process.env.SEARCH_INTENT_TOOL_BOOST_RULES_JSON;
+    delete process.env.MCP_PORT;
+    delete process.env.CAPTCHA_API_KEY;
+    delete process.env.CAPTCHA_SOLVER_BASE_URL;
     mockMissingEnvFile();
   });
 
@@ -131,6 +134,39 @@ describe('config utilities', () => {
     expect(result.valid).toBe(false);
     expect(result.errors).toContain('maxConcurrentAnalysis must be at least 1');
     expect(result.errors).toContain('maxCodeSizeMB must be at least 1');
+  });
+
+  it('fails startup on invalid environment variables', async () => {
+    process.env.MCP_PORT = '99999'; // Invalid port > 65535
+
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const processExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called');
+    });
+
+    await expect(async () => {
+      const { getConfig } = await import('@utils/config');
+      getConfig();
+    }).rejects.toThrow('process.exit called');
+
+    expect(consoleError).toHaveBeenCalledWith(expect.stringContaining('Validation errors'));
+    expect(processExit).toHaveBeenCalledWith(1);
+
+    consoleError.mockRestore();
+    processExit.mockRestore();
+  });
+
+  it('accepts valid environment variables', async () => {
+    process.env.MCP_PORT = '3000';
+    process.env.CAPTCHA_API_KEY = 'validapikey123456789';
+    process.env.CAPTCHA_SOLVER_BASE_URL = 'https://api.example.com';
+
+    const { getConfig } = await import('@utils/config');
+    const config = getConfig();
+
+    expect(config.validation.mcpPort).toBe(3000);
+    expect(config.validation.captchaApiKey).toBe('validapikey123456789');
+    expect(config.validation.captchaSolverBaseUrl).toBe('https://api.example.com');
   });
 
   it('reads search rule overrides from environment json', async () => {

--- a/tests/utils/logger.test.ts
+++ b/tests/utils/logger.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { logger } from '@utils/logger';
+import { logger, Logger } from '@utils/logger';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 describe('logger', () => {
   beforeEach(() => {
@@ -99,5 +102,65 @@ describe('logger', () => {
     logger.setLevel('warn');
     logger.success('this should be hidden');
     expect(console.error).toHaveBeenCalledTimes(0);
+  });
+
+  describe('file logging', () => {
+    let tempLogFile: string;
+
+    beforeEach(async () => {
+      tempLogFile = join(tmpdir(), `test-log-${Date.now()}.log`);
+      vi.restoreAllMocks();
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(async () => {
+      try {
+        await fs.unlink(tempLogFile);
+      } catch {
+        // Ignore if file doesn't exist
+      }
+    });
+
+    it('creates log file with secure permissions when filePath is provided', async () => {
+      const fileLogger = new Logger({ level: 'info', filePath: tempLogFile });
+
+      // Wait for file initialization
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      fileLogger.info('test message');
+
+      // Check file was created
+      const stats = await fs.stat(tempLogFile);
+      expect(stats.isFile()).toBe(true);
+
+      // Check permissions (0600)
+      const mode = stats.mode & 0o777;
+      expect(mode).toBe(0o600);
+
+      // Check content
+      const content = await fs.readFile(tempLogFile, 'utf-8');
+      expect(content).toContain('test message');
+      expect(content).toContain('[INFO]');
+
+      fileLogger.close();
+    });
+
+    it('logs to both console and file', async () => {
+      const fileLogger = new Logger({ level: 'info', filePath: tempLogFile });
+
+      // Wait for file initialization
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      fileLogger.info('dual output test');
+
+      expect(console.error).toHaveBeenCalledTimes(1);
+      const consoleOutput = String((console.error as any).mock.calls[0]![0]);
+      expect(consoleOutput).toContain('dual output test');
+
+      const fileContent = await fs.readFile(tempLogFile, 'utf-8');
+      expect(fileContent).toContain('dual output test');
+
+      fileLogger.close();
+    });
   });
 });


### PR DESCRIPTION
## What

Resubmitting the deobfuscation expansion in smaller PRs after the original got auto-closed for hitting the 150k diff char limit. Also rolls in the four issues Gemini Code Assist flagged on the original.

This is PR 1/5: webcrack hardening + shared config/utils. The rest follow.

## The fixes

**Sandbox escape via `node:vm` fallback** (`webcrack.ts`)

We were falling back to `node:vm.createContext()` when `isolated-vm` wasn't available. That's not a sandbox — `this.constructor.constructor('return process')()` walks straight out. Killed the fallback. If `isolated-vm` is missing we log a warning and pass `sandbox: false` so webcrack skips eval-based string-array decoding. Don't process untrusted samples without isolated-vm installed.

**Path traversal in `outputDir`** (`webcrack.ts`)

`path.resolve(outputDir)` followed by `rm(savedTo, { recursive: true, force: true })` was effectively `rm -rf` on attacker-controlled input. Added a containment check (`startsWith(cwd + sep)`) plus a `realpath()` pass so a symlinked outputDir pointing outside cwd gets rejected. Non-existent paths are fine — there's nothing to symlink yet.

## What else is in here

- `DeobfuscationConfig` — shared constants, timeout guards, input size limits
- `DeobfuscationPipeline` — base pipeline orchestration
- `ProApiClient` — JavaScript Obfuscator Pro API integration
- Refreshed types, utils, config, logger, and CI workflow
- Updated README with new deobfuscation capabilities

## Test plan

- [ ] webcrack runs with `isolated-vm` installed and uses it
- [ ] webcrack runs without `isolated-vm` and warns instead of falling back to vm
- [ ] outputDir of `../foo` rejected
- [ ] outputDir of `/etc/foo` rejected
- [ ] outputDir that resolves through a symlink outside cwd rejected
- [ ] outputDir inside cwd succeeds and saves artifacts
- [ ] vitest green, oxlint clean

Closes the four findings from the original PR's review thread.

## Summary by Sourcery

Harden webcrack sandboxing and HTTP health endpoint, introduce a structured deobfuscation pipeline with optional Obfuscator.io Pro API integration, and tighten configuration, logging, and filesystem security across the project.

New Features:
- Add a configurable deobfuscation pipeline that chains unpacking, AST-based cleanup, and webcrack, with detailed step tracking and readability scoring.
- Integrate optional Obfuscator.io Pro API support via ProApiClient, including CLI flags and env-based configuration for Pro features.
- Extend deobfuscation capabilities with detection/handling of additional obfuscation types (e.g., base64/hex encoding, JSFuck, jsdecode, proxy/with obfuscation) and richer AST optimizations.
- Add secure file utilities and logger file output support for writing logs and cache data with restrictive permissions.
- Expose new validation config surface for runtime and transport tuning, including structured env validation and failure on invalid configuration.

Bug Fixes:
- Remove insecure node:vm fallback from webcrack sandbox usage and add path traversal/symlink escape protections for output directories.
- Prevent HTTP health endpoint from leaking token budget details and gate verbose output behind auth and a query flag.
- Handle malformed URLEncoding more safely in deobfuscation by downgrading specific URI errors to warnings instead of generic failures.

Enhancements:
- Broaden bundle support in webcrack and deobfuscation types to include vite, rollup, parcel and generic bundle identifiers.
- Strengthen deobfuscator error reporting with structured JSON error payloads from AST and VM deobfuscation failures.
- Improve config validation with stricter schemas for URLs, ports, API keys, numeric ranges, and path safety, and fail fast on invalid env.
- Refine obfuscation detection and readability scoring heuristics for more nuanced analysis of input code.
- Allow deobfuscators that use ExecutionSandbox to accept an injected sandbox instance for better testability and reuse.
- Enhance HTTP transport with centralized security headers (except for health checks) and a slightly expanded health handler interface.
- Update logger to support levelled file logging while redacting sensitive values and preserving MCP stdout semantics.

Build:
- Adjust dependencies to add deobfuscation-related tooling (AST, HTTP, DB, rate limiting) and dev utilities like nodemon, while updating some existing versions.

CI:
- Extend CI workflow with a security audit step using pnpm audit before running tests and linters.

Documentation:
- Document CLI and environment configuration for Obfuscator.io Pro API usage in the README, including examples for tokens and versions.

Tests:
- Add and update tests for config validation, logger file output, webcrack path handling, new obfuscation detectors, VM deobfuscator behavior, and Pro API client integration paths to keep coverage over new functionality.