### PR TITLE
feat(dart-inspector): wire dart_strings_extract tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ The built-in surface below is generated from the runtime registry and checked in
 
 <!-- metadata-sync:start -->
 - Package version: `0.3.1`
-- Built-in Tools: `411`
-- Domains: `adb-bridge`, `antidebug`, `binary-instrument`, `boringssl-inspector`, `browser`, `canvas`, `coordination`, `core`, `cross-domain`, `debugger`, `encoding`, `evidence`, `extension-registry`, `graphql`, `hooks`, `instrumentation`, `macro`, `maintenance`, `memory`, `mojo-ipc`, `network`, `platform`, `process`, `protocol-analysis`, `proxy`, `sandbox`, `shared-state-board`, `skia-capture`, `sourcemap`, `streaming`, `syscall-hook`, `trace`, `transform`, `v8-inspector`, `wasm`, `workflow`
+- Built-in Tools: `412`
+- Domains: `adb-bridge`, `antidebug`, `binary-instrument`, `boringssl-inspector`, `browser`, `canvas`, `coordination`, `core`, `cross-domain`, `dart-inspector`, `debugger`, `encoding`, `evidence`, `extension-registry`, `graphql`, `hooks`, `instrumentation`, `macro`, `maintenance`, `memory`, `mojo-ipc`, `network`, `platform`, `process`, `protocol-analysis`, `proxy`, `sandbox`, `shared-state-board`, `skia-capture`, `sourcemap`, `streaming`, `syscall-hook`, `trace`, `transform`, `v8-inspector`, `wasm`, `workflow`
 - Note: this snapshot is generated from the runtime registry; do not edit the counts by hand.
 <!-- metadata-sync:end -->
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -66,8 +66,8 @@
 
 <!-- metadata-sync:start -->
 - 包版本：`0.3.1`
-- 内置工具数：`411`
-- 域列表：`adb-bridge`, `antidebug`, `binary-instrument`, `boringssl-inspector`, `browser`, `canvas`, `coordination`, `core`, `cross-domain`, `debugger`, `encoding`, `evidence`, `extension-registry`, `graphql`, `hooks`, `instrumentation`, `macro`, `maintenance`, `memory`, `mojo-ipc`, `network`, `platform`, `process`, `protocol-analysis`, `proxy`, `sandbox`, `shared-state-board`, `skia-capture`, `sourcemap`, `streaming`, `syscall-hook`, `trace`, `transform`, `v8-inspector`, `wasm`, `workflow`
+- 内置工具数：`412`
+- 域列表：`adb-bridge`, `antidebug`, `binary-instrument`, `boringssl-inspector`, `browser`, `canvas`, `coordination`, `core`, `cross-domain`, `dart-inspector`, `debugger`, `encoding`, `evidence`, `extension-registry`, `graphql`, `hooks`, `instrumentation`, `macro`, `maintenance`, `memory`, `mojo-ipc`, `network`, `platform`, `process`, `protocol-analysis`, `proxy`, `sandbox`, `shared-state-board`, `skia-capture`, `sourcemap`, `streaming`, `syscall-hook`, `trace`, `transform`, `v8-inspector`, `wasm`, `workflow`
 - 说明：以上数据由运行时 registry 动态生成，不要手改计数。
 <!-- metadata-sync:end -->
 

--- a/docs/.vitepress/i18n/zh/reference-tool-descriptions.json
+++ b/docs/.vitepress/i18n/zh/reference-tool-descriptions.json
@@ -409,5 +409,6 @@
   "sourcemap_coverage": "汇总 source map 的已映射与未映射源码覆盖范围。",
   "sourcemap_lookup": "将生成代码的位置（行号:列号）反向映射到原始源码位置。",
   "js_symbolic_execute": "JavaScript 符号执行：探索所有可行执行路径，收集路径约束并求解。适用于控制流平坦化后的复杂分支代码分析。",
-  "js_symbolic_execute_jsvmp": "JSVMP 字节码符号执行：逐步对指令进行符号执行，推断原始逻辑、约束和置信度。需先使用 js_analyze_vm 获取指令序列。"
+  "js_symbolic_execute_jsvmp": "JSVMP 字节码符号执行：逐步对指令进行符号执行，推断原始逻辑、约束和置信度。需先使用 js_analyze_vm 获取指令序列。",
+  "dart_strings_extract": "从 Flutter libapp.so 抽取并分类可见字符串，识别 URL、路径、类名、包引用与加密关键字。"
 }

--- a/docs/en/reference/domains/dart-inspector.md
+++ b/docs/en/reference/domains/dart-inspector.md
@@ -1,0 +1,26 @@
+# Dart Inspector
+
+Domain: `dart-inspector`
+
+Extract and classify strings from Flutter AOT libapp.so (URLs, paths, class names, package refs, crypto keywords).
+
+## Profiles
+
+- full
+
+## Typical scenarios
+
+- Flutter app reversing
+- libapp.so string audit
+- Crypto keyword location
+
+## Common combinations
+
+- dart-inspector + binary-instrument
+- dart-inspector + adb-bridge
+
+## Full tool list (1)
+
+| Tool | Description |
+| --- | --- |
+| `dart_strings_extract` | Extract and classify printable strings from a Dart AOT libapp.so (or any binary). Streams the file in chunks, scans ASCII and/or UTF-16LE runs, merges offsets, and categorizes hits (urls, paths, classNames, packageRefs, cryptoKeywords, plus any customRules). Includes ReDoS guards for user-supplied regex rules. |

--- a/docs/en/reference/index.md
+++ b/docs/en/reference/index.md
@@ -21,6 +21,7 @@ The following tool domains are available:
 | `coordination` | Coordination | full | Coordination domain for session insights and MCP Task Handoff, bridging the planning and execution boundaries of LLMs. |
 | `core` | Core | workflow, full | Core static and semi-static analysis domain for script collection, deobfuscation, semantic inspection, webpack analysis, source map recovery, and crypto detection. |
 | `cross-domain` | Cross-Domain | full | Cross-domain correlation domain that bridges analysis results across multiple domains, supporting workflow orchestration and evidence graph integration. |
+| `dart-inspector` | Dart Inspector | full | Extract and classify strings from Flutter AOT libapp.so (URLs, paths, class names, package refs, crypto keywords). |
 | `debugger` | Debugger | workflow, full | CDP-based debugging domain covering breakpoints, stepping, call stacks, watches, and debugger sessions. |
 | `encoding` | Encoding | workflow, full | Binary format detection, encoding conversion, entropy analysis, and raw protobuf decoding. |
 | `evidence` | Evidence | full | Evidence-graph domain that models provenance between URLs, scripts, functions, hooks, and captured artifacts. |

--- a/docs/reference/domains/dart-inspector.md
+++ b/docs/reference/domains/dart-inspector.md
@@ -1,0 +1,26 @@
+# Dart Inspector
+
+域名：`dart-inspector`
+
+从 Flutter AOT libapp.so 中抽取并分类字符串（URL、路径、类名、包引用、加密关键字）。
+
+## Profile
+
+- full
+
+## 典型场景
+
+- Flutter 应用逆向
+- libapp.so 字符串审计
+- 加密关键字定位
+
+## 常见组合
+
+- dart-inspector + binary-instrument
+- dart-inspector + adb-bridge
+
+## 工具清单（1）
+
+| 工具 | 说明 |
+| --- | --- |
+| `dart_strings_extract` | 从 Flutter libapp.so 抽取并分类可见字符串，识别 URL、路径、类名、包引用与加密关键字。 |

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -21,6 +21,7 @@
 | `coordination` | Coordination | full | 用于会话洞察记录与 MCP Task Handoff 的协调域，衔接大语言模型的规划与执行。 |
 | `core` | Core | workflow, full | 核心静态/半静态分析域，覆盖脚本采集、反混淆、语义理解、webpack/source map 与加密识别。 |
 | `cross-domain` | Cross-Domain | full | 跨域关联域，将多个域的分析结果进行交叉关联，支持自动化工作流编排与证据图桥接。 |
+| `dart-inspector` | Dart Inspector | full | 从 Flutter AOT libapp.so 中抽取并分类字符串（URL、路径、类名、包引用、加密关键字）。 |
 | `debugger` | Debugger | workflow, full | 基于 CDP 的断点、单步、调用栈、watch 与调试会话管理域。 |
 | `encoding` | Encoding | workflow, full | 二进制格式检测、编码转换、熵分析与 protobuf 原始解码。 |
 | `evidence` | Evidence | full | 逆向证据图域，用图结构串联 URL、脚本、函数、Hook 与捕获产物之间的溯源关系。 |

--- a/scripts/generate-vitepress-reference.mjs
+++ b/scripts/generate-vitepress-reference.mjs
@@ -445,6 +445,18 @@ const META = {
     enScenarios: ['TLS traffic analysis', 'Certificate parsing', 'Key log capture'],
     enCombos: ['boringssl-inspector + network', 'boringssl-inspector + browser'],
   },
+  'dart-inspector': {
+    zhTitle: 'Dart Inspector',
+    zhSummary:
+      '从 Flutter AOT libapp.so 中抽取并分类字符串（URL、路径、类名、包引用、加密关键字）。',
+    zhScenarios: ['Flutter 应用逆向', 'libapp.so 字符串审计', '加密关键字定位'],
+    zhCombos: ['dart-inspector + binary-instrument', 'dart-inspector + adb-bridge'],
+    enTitle: 'Dart Inspector',
+    enSummary:
+      'Extract and classify strings from Flutter AOT libapp.so (URLs, paths, class names, package refs, crypto keywords).',
+    enScenarios: ['Flutter app reversing', 'libapp.so string audit', 'Crypto keyword location'],
+    enCombos: ['dart-inspector + binary-instrument', 'dart-inspector + adb-bridge'],
+  },
   'extension-registry': {
     zhTitle: 'Extension Registry',
     zhSummary: '扩展注册域，管理和发现社区扩展。',

--- a/src/server/MCPServer.context.ts
+++ b/src/server/MCPServer.context.ts
@@ -14,6 +14,7 @@ import type { ADBBridgeHandlers } from '@server/domains/adb-bridge/handlers';
 import type { BinaryInstrumentHandlers } from '@server/domains/binary-instrument/handlers';
 import type { BoringsslInspectorHandlers } from '@server/domains/boringssl-inspector/handlers';
 import type { CrossDomainHandlers } from '@server/domains/cross-domain/handlers';
+import type { DartInspectorHandlers } from '@server/domains/dart-inspector/handlers';
 import type { ExtensionRegistryHandlers } from '@server/domains/extension-registry/handlers';
 import type { MojoIPCHandlers } from '@server/domains/mojo-ipc/handlers';
 import type { ProtocolAnalysisHandlers } from '@server/domains/protocol-analysis/handlers';
@@ -136,6 +137,7 @@ export interface DomainInstances {
   protocolAnalysisHandlers?: ProtocolAnalysisHandlers;
   extensionRegistryHandlers?: ExtensionRegistryHandlers;
   crossDomainHandlers?: CrossDomainHandlers;
+  dartInspectorHandlers?: DartInspectorHandlers;
   debuggerHandlers?: import('@server/domains/debugger/index').DebuggerToolHandlers;
   advancedHandlers?: import('@server/domains/network/index').AdvancedToolHandlers;
   aiHookHandlers?: import('@server/domains/hooks/index').AIHookToolHandlers;

--- a/src/server/domains/dart-inspector/definitions.ts
+++ b/src/server/domains/dart-inspector/definitions.ts
@@ -1,0 +1,59 @@
+import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import { tool } from '@server/registry/tool-builder';
+
+export const dartInspectorTools: Tool[] = [
+  tool('dart_strings_extract', (t) =>
+    t
+      .desc(
+        'Extract and classify printable strings from a Dart AOT libapp.so (or any binary). ' +
+          'Streams the file in chunks, scans ASCII and/or UTF-16LE runs, merges offsets, and ' +
+          'categorizes hits (urls, paths, classNames, packageRefs, cryptoKeywords, plus any ' +
+          'customRules). Includes ReDoS guards for user-supplied regex rules.',
+      )
+      .string('filePath', 'Absolute path to the libapp.so (or arbitrary binary) to extract from')
+      .number('minLength', 'Minimum string length to emit', { default: 4, minimum: 2, maximum: 64 })
+      .boolean('includeRaw', 'Include unclassified strings under the `raw` bucket', {
+        default: false,
+      })
+      .boolean('includeOffsets', 'Include byte offsets[] for each extracted string', {
+        default: true,
+      })
+      .enum('encoding', ['ascii', 'utf16le', 'both'], 'Which encodings to scan', {
+        default: 'both',
+      })
+      .number('maxChunkBytes', 'Streaming chunk size in bytes')
+      .number('maxOffsetsPerString', 'Cap on offsets recorded per string (excess sets truncated)', {
+        default: 1000,
+      })
+      .enum(
+        'ruleMode',
+        ['append', 'prepend', 'replace'],
+        'How customRules interact with DEFAULT_RULES',
+        { default: 'append' },
+      )
+      .number('regexTimeoutMs', 'Per-rule .test() wall-clock budget for the ReDoS guard')
+      .array(
+        'customRules',
+        {
+          type: 'object',
+          properties: {
+            category: { type: 'string', description: 'Category bucket name for matched strings' },
+            pattern: { type: 'string', description: 'Regex source (anchored as needed)' },
+            flags: {
+              type: 'string',
+              description: 'Regex flags (must be in DART_ALLOWED_REGEX_FLAGS)',
+            },
+            exclude: {
+              type: 'string',
+              description: 'Optional exclude regex applied before category match',
+            },
+            excludeFlags: { type: 'string', description: 'Flags for the exclude regex' },
+          },
+          required: ['category', 'pattern'],
+        },
+        'Custom classification rules with safe regex compilation (ReDoS-guarded)',
+      )
+      .required('filePath')
+      .query(),
+  ),
+];

--- a/src/server/domains/dart-inspector/handlers.impl.ts
+++ b/src/server/domains/dart-inspector/handlers.impl.ts
@@ -1,0 +1,94 @@
+/**
+ * dart-inspector domain — single tool handler that wraps the
+ * {@link StringsExtractor} module.
+ *
+ * Responsibilities:
+ *  - Type-safe argument extraction via `parseArgs` utilities.
+ *  - Compile every customRule input into a `CategoryRule` (rejecting
+ *    ReDoS heuristics and invalid regex with a `ToolError(VALIDATION)`).
+ *  - Defer streaming extraction and categorization to the module layer.
+ *  - Wrap the result in the standard MCP envelope via {@link handleSafe}.
+ */
+
+import { StringsExtractor } from '@modules/dart-inspector/StringsExtractor';
+import { compileRuleInput } from '@modules/dart-inspector/classifiers';
+import type {
+  CategoryRule,
+  CategoryRuleInput,
+  ExtractOptions,
+  RuleMode,
+} from '@modules/dart-inspector/types';
+import { ToolError } from '@errors/ToolError';
+import { handleSafe } from '@server/domains/shared/ResponseBuilder';
+import type { ToolResponse } from '@server/types';
+import { argBool, argEnum, argNumber, argStringRequired } from '@server/domains/shared/parse-args';
+
+const ENCODING_SET = new Set(['ascii', 'utf16le', 'both'] as const);
+const RULE_MODE_SET = new Set(['append', 'prepend', 'replace'] as const);
+
+/**
+ * Coerce the raw `customRules` argument into a list of compiled
+ * {@link CategoryRule}s, throwing {@link ToolError}(`VALIDATION`) on
+ * malformed shape.
+ */
+function compileCustomRules(raw: unknown): CategoryRule[] | undefined {
+  if (raw === undefined || raw === null) return undefined;
+  if (!Array.isArray(raw)) {
+    throw new ToolError('VALIDATION', 'customRules must be an array of rule objects');
+  }
+  return raw.map((entry, index) => {
+    if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) {
+      throw new ToolError('VALIDATION', `customRules[${index}] must be an object`);
+    }
+    const input = entry as Record<string, unknown>;
+    const { category, pattern, flags, exclude, excludeFlags } = input;
+    if (typeof category !== 'string') {
+      throw new ToolError('VALIDATION', `customRules[${index}].category must be a string`);
+    }
+    if (typeof pattern !== 'string') {
+      throw new ToolError('VALIDATION', `customRules[${index}].pattern must be a string`);
+    }
+    const ruleInput: CategoryRuleInput = { category, pattern };
+    if (typeof flags === 'string') ruleInput.flags = flags;
+    if (typeof exclude === 'string') ruleInput.exclude = exclude;
+    if (typeof excludeFlags === 'string') ruleInput.excludeFlags = excludeFlags;
+    return compileRuleInput(ruleInput);
+  });
+}
+
+export class DartInspectorHandlers {
+  private readonly extractor: StringsExtractor;
+
+  constructor(extractor: StringsExtractor = new StringsExtractor()) {
+    this.extractor = extractor;
+  }
+
+  handleDartStringsExtract(args: Record<string, unknown>): Promise<ToolResponse> {
+    return handleSafe(async () => {
+      const filePath = argStringRequired(args, 'filePath');
+      const customRules = compileCustomRules(args['customRules']);
+
+      const opts: ExtractOptions = {};
+      const minLength = argNumber(args, 'minLength');
+      if (minLength !== undefined) opts.minLength = minLength;
+      const includeRaw = argBool(args, 'includeRaw');
+      if (includeRaw !== undefined) opts.includeRaw = includeRaw;
+      const includeOffsets = argBool(args, 'includeOffsets');
+      if (includeOffsets !== undefined) opts.includeOffsets = includeOffsets;
+      const encoding = argEnum(args, 'encoding', ENCODING_SET);
+      if (encoding !== undefined) opts.encoding = encoding;
+      const maxChunkBytes = argNumber(args, 'maxChunkBytes');
+      if (maxChunkBytes !== undefined) opts.maxChunkBytes = maxChunkBytes;
+      const maxOffsetsPerString = argNumber(args, 'maxOffsetsPerString');
+      if (maxOffsetsPerString !== undefined) opts.maxOffsetsPerString = maxOffsetsPerString;
+      const ruleMode = argEnum(args, 'ruleMode', RULE_MODE_SET) as RuleMode | undefined;
+      if (ruleMode !== undefined) opts.ruleMode = ruleMode;
+      const regexTimeoutMs = argNumber(args, 'regexTimeoutMs');
+      if (regexTimeoutMs !== undefined) opts.regexTimeoutMs = regexTimeoutMs;
+      if (customRules !== undefined) opts.customRules = customRules;
+
+      const strings = await this.extractor.extractFromFile(filePath, opts);
+      return { strings };
+    });
+  }
+}

--- a/src/server/domains/dart-inspector/handlers.ts
+++ b/src/server/domains/dart-inspector/handlers.ts
@@ -1,0 +1,1 @@
+export * from '@server/domains/dart-inspector/handlers.impl';

--- a/src/server/domains/dart-inspector/index.ts
+++ b/src/server/domains/dart-inspector/index.ts
@@ -1,0 +1,2 @@
+export { dartInspectorTools } from '@server/domains/dart-inspector/definitions';
+export { DartInspectorHandlers } from '@server/domains/dart-inspector/handlers';

--- a/src/server/domains/dart-inspector/manifest.ts
+++ b/src/server/domains/dart-inspector/manifest.ts
@@ -1,0 +1,35 @@
+import type { DomainManifest, MCPServerContext } from '@server/domains/shared/registry';
+import { defineMethodRegistrations, toolLookup } from '@server/domains/shared/registry';
+import { dartInspectorTools } from '@server/domains/dart-inspector/definitions';
+import type { DartInspectorHandlers } from '@server/domains/dart-inspector/index';
+
+const DOMAIN = 'dart-inspector' as const;
+const DEP_KEY = 'dartInspectorHandlers' as const;
+type H = DartInspectorHandlers;
+const t = toolLookup(dartInspectorTools);
+const registrations = defineMethodRegistrations<H, (typeof dartInspectorTools)[number]['name']>({
+  domain: DOMAIN,
+  depKey: DEP_KEY,
+  lookup: t,
+  entries: [{ tool: 'dart_strings_extract', method: 'handleDartStringsExtract' }],
+});
+
+async function ensure(ctx: MCPServerContext): Promise<H> {
+  const { DartInspectorHandlers } = await import('@server/domains/dart-inspector/index');
+  if (!ctx.dartInspectorHandlers) {
+    ctx.dartInspectorHandlers = new DartInspectorHandlers();
+  }
+  return ctx.dartInspectorHandlers;
+}
+
+const manifest: DomainManifest<typeof DEP_KEY, H, typeof DOMAIN> = {
+  kind: 'domain-manifest',
+  version: 1,
+  domain: DOMAIN,
+  depKey: DEP_KEY,
+  profiles: ['full'],
+  ensure,
+  registrations,
+};
+
+export default manifest;

--- a/tests/server/domains/dart-inspector/handlers.test.ts
+++ b/tests/server/domains/dart-inspector/handlers.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Tests for DartInspectorHandlers — the domain handler that wraps
+ * the {@link StringsExtractor} module behind the MCP tool surface.
+ *
+ * Covers validation, regex-rule compilation (ReDoS), rule modes,
+ * offset truncation, and includeOffsets toggling.
+ *
+ * The handler returns a wrapped ToolResponse (`R.ok().merge(...).json()`),
+ * so tests parse the response via {@link R.parse} before asserting.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { resolve } from 'node:path';
+
+import { DartInspectorHandlers } from '@server/domains/dart-inspector/handlers';
+import { R } from '@server/domains/shared/ResponseBuilder';
+
+const FIXTURE_PATH = resolve(__dirname, '../../../fixtures/dart-inspector/tiny-libapp.so');
+
+describe('DartInspectorHandlers', () => {
+  let handlers: DartInspectorHandlers;
+
+  beforeAll(() => {
+    handlers = new DartInspectorHandlers();
+  });
+
+  describe('handleDartStringsExtract — happy path', () => {
+    it('returns wrapped success response with the 5 default categories', async () => {
+      const response = await handlers.handleDartStringsExtract({ filePath: FIXTURE_PATH });
+      const body = R.parse<{
+        success: boolean;
+        strings: Record<string, unknown[]>;
+      }>(response);
+
+      expect(body.success).toBe(true);
+      expect(body.strings).toBeDefined();
+      expect(body.strings.urls).toBeDefined();
+      expect(body.strings.paths).toBeDefined();
+      expect(body.strings.classNames).toBeDefined();
+      expect(body.strings.packageRefs).toBeDefined();
+      expect(body.strings.cryptoKeywords).toBeDefined();
+    });
+  });
+
+  describe('handleDartStringsExtract — validation errors', () => {
+    it('returns failure when filePath is missing', async () => {
+      const response = await handlers.handleDartStringsExtract({});
+      const body = R.parse<{ success: boolean; error: string }>(response);
+      expect(body.success).toBe(false);
+      expect(typeof body.error).toBe('string');
+      expect(body.error.length).toBeGreaterThan(0);
+    });
+
+    it('returns NOT_FOUND failure when file does not exist', async () => {
+      const response = await handlers.handleDartStringsExtract({
+        filePath: '/nonexistent/path/to/missing-libapp.so',
+      });
+      const body = R.parse<{ success: boolean; error: string }>(response);
+      expect(body.success).toBe(false);
+      expect(body.error).toMatch(/not found|ENOENT/i);
+    });
+  });
+
+  describe('handleDartStringsExtract — customRules', () => {
+    it('accepts a valid custom rule with flags', async () => {
+      const response = await handlers.handleDartStringsExtract({
+        filePath: FIXTURE_PATH,
+        customRules: [{ pattern: '^FLAG_', flags: 'i', category: 'flags' }],
+      });
+      const body = R.parse<{ success: boolean; strings: Record<string, unknown> }>(response);
+      expect(body.success).toBe(true);
+      expect(body.strings).toHaveProperty('flags');
+    });
+
+    it('rejects an invalid regex with VALIDATION failure', async () => {
+      const response = await handlers.handleDartStringsExtract({
+        filePath: FIXTURE_PATH,
+        customRules: [{ pattern: '(', category: 'evil' }],
+      });
+      const body = R.parse<{ success: boolean; error: string }>(response);
+      expect(body.success).toBe(false);
+      expect(body.error.toLowerCase()).toMatch(/compile|invalid|regex|syntax/);
+    });
+
+    it('rejects a catastrophic-backtracking pattern (ReDoS heuristic)', async () => {
+      const response = await handlers.handleDartStringsExtract({
+        filePath: FIXTURE_PATH,
+        customRules: [{ pattern: '(a+)+', category: 'evil' }],
+      });
+      const body = R.parse<{ success: boolean; error: string }>(response);
+      expect(body.success).toBe(false);
+      expect(body.error.toLowerCase()).toContain('catastrophic');
+    });
+  });
+
+  describe('handleDartStringsExtract — ruleMode', () => {
+    const customRule = { pattern: '^https?://', flags: 'i', category: 'customUrls' };
+
+    it('append mode keeps defaults and adds custom category', async () => {
+      const response = await handlers.handleDartStringsExtract({
+        filePath: FIXTURE_PATH,
+        ruleMode: 'append',
+        customRules: [customRule],
+      });
+      const body = R.parse<{ success: boolean; strings: Record<string, unknown> }>(response);
+      expect(body.success).toBe(true);
+      // urls (default) wins over customUrls because defaults come first in append.
+      expect(body.strings).toHaveProperty('urls');
+      expect(body.strings).toHaveProperty('customUrls');
+    });
+
+    it('prepend mode lets custom rules win over defaults', async () => {
+      const response = await handlers.handleDartStringsExtract({
+        filePath: FIXTURE_PATH,
+        ruleMode: 'prepend',
+        customRules: [customRule],
+      });
+      const body = R.parse<{
+        success: boolean;
+        strings: Record<string, Array<{ value: string }>>;
+      }>(response);
+      expect(body.success).toBe(true);
+      expect(body.strings).toHaveProperty('customUrls');
+      // In prepend mode, the URL strings land in `customUrls` rather than `urls`.
+      const customUrls = body.strings.customUrls ?? [];
+      const defaultUrls = body.strings.urls ?? [];
+      expect(customUrls.length).toBeGreaterThan(defaultUrls.length);
+    });
+
+    it('replace mode removes default categories', async () => {
+      const response = await handlers.handleDartStringsExtract({
+        filePath: FIXTURE_PATH,
+        ruleMode: 'replace',
+        customRules: [customRule],
+      });
+      const body = R.parse<{ success: boolean; strings: Record<string, unknown> }>(response);
+      expect(body.success).toBe(true);
+      expect(body.strings).toHaveProperty('customUrls');
+      // Default categories should NOT be present when replaced.
+      expect(body.strings).not.toHaveProperty('classNames');
+      expect(body.strings).not.toHaveProperty('packageRefs');
+    });
+  });
+
+  describe('handleDartStringsExtract — option toggles', () => {
+    it('omits offsets field when includeOffsets is false', async () => {
+      const response = await handlers.handleDartStringsExtract({
+        filePath: FIXTURE_PATH,
+        includeOffsets: false,
+      });
+      const body = R.parse<{
+        success: boolean;
+        strings: Record<string, Array<Record<string, unknown>>>;
+      }>(response);
+      expect(body.success).toBe(true);
+
+      for (const items of Object.values(body.strings)) {
+        for (const item of items) {
+          expect(item).not.toHaveProperty('offsets');
+        }
+      }
+    });
+
+    it('truncates offsets when maxOffsetsPerString is exceeded', async () => {
+      // The fixture has `TRIPLE_TOKEN_VALUE_AA` at three offsets — cap to 2.
+      const response = await handlers.handleDartStringsExtract({
+        filePath: FIXTURE_PATH,
+        maxOffsetsPerString: 2,
+        includeRaw: true,
+      });
+      const body = R.parse<{
+        success: boolean;
+        strings: Record<string, Array<{ value: string; offsets: number[]; truncated?: boolean }>>;
+      }>(response);
+      expect(body.success).toBe(true);
+
+      const raw = body.strings.raw ?? [];
+      const triple = raw.find((item) => item.value === 'TRIPLE_TOKEN_VALUE_AA');
+      expect(triple).toBeDefined();
+      expect(triple!.offsets.length).toBe(2);
+      expect(triple!.truncated).toBe(true);
+    });
+  });
+});

--- a/tests/server/domains/dart-inspector/integration.test.ts
+++ b/tests/server/domains/dart-inspector/integration.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Integration tests for the dart-inspector domain — Phase 3.
+ *
+ * Verifies the domain is discoverable by the registry and the
+ * registered `dart_strings_extract` tool can be invoked end-to-end
+ * against the committed tiny-libapp.so fixture.
+ *
+ * @see openspec/changes/add-dart-strings-extract/tasks.md §3
+ */
+import { describe, expect, it } from 'vitest';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { readFile } from 'node:fs/promises';
+
+import manifest from '@server/domains/dart-inspector/manifest';
+import type { MCPServerContext } from '@server/MCPServer.context';
+import { R } from '@server/domains/shared/ResponseBuilder';
+import { discoverDomainManifests } from '@server/registry/discovery';
+
+const FIXTURE_DIR = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  '..',
+  'fixtures',
+  'dart-inspector',
+);
+const TINY_LIBAPP = join(FIXTURE_DIR, 'tiny-libapp.so');
+const EXPECTED_JSON = join(FIXTURE_DIR, 'expected-strings.json');
+
+describe('dart-inspector integration', () => {
+  it('is discoverable by the registry', async () => {
+    const manifests = await discoverDomainManifests();
+    const found = manifests.find((m) => m.domain === 'dart-inspector');
+    expect(found).toBeDefined();
+    expect(found?.depKey).toBe('dartInspectorHandlers');
+  });
+
+  it('registry exposes dart_strings_extract via the manifest registrations', () => {
+    const toolNames = manifest.registrations.map((r) => r.tool.name);
+    expect(toolNames).toEqual(['dart_strings_extract']);
+  });
+
+  it('end-to-end call returns the expected categories for the tiny libapp fixture', async () => {
+    const ctx = {} as MCPServerContext;
+    const handler = await manifest.ensure(ctx);
+    const response = await handler.handleDartStringsExtract({ filePath: TINY_LIBAPP });
+    const payload = R.parse<{ success: boolean; strings: Record<string, unknown[]> }>(response);
+
+    expect(payload.success).toBe(true);
+    expect(payload.strings).toBeDefined();
+
+    const expected = JSON.parse(await readFile(EXPECTED_JSON, 'utf-8')) as {
+      categories: Record<string, Array<{ value: string }>>;
+    };
+
+    for (const [category, items] of Object.entries(expected.categories)) {
+      const actualValues = (payload.strings[category] as Array<{ value: string }> | undefined)?.map(
+        (s) => s.value,
+      );
+      const expectedValues = items.map((s) => s.value).toSorted();
+      expect(actualValues?.toSorted()).toEqual(expectedValues);
+    }
+  });
+
+  it('end-to-end call surfaces ToolError for a missing file', async () => {
+    const ctx = {} as MCPServerContext;
+    const handler = await manifest.ensure(ctx);
+    const response = await handler.handleDartStringsExtract({
+      filePath: join(FIXTURE_DIR, 'does-not-exist.bin'),
+    });
+    const payload = R.parse<{ success: boolean; error?: string }>(response);
+    expect(payload.success).toBe(false);
+    expect(payload.error).toBeDefined();
+  });
+});

--- a/tests/server/domains/dart-inspector/manifest.test.ts
+++ b/tests/server/domains/dart-inspector/manifest.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Manifest contract tests for the dart-inspector domain.
+ *
+ * Validates the DomainManifest shape, profile membership, registrations,
+ * and the lazy `ensure()` factory (instance caching + idempotence).
+ */
+import { describe, it, expect } from 'vitest';
+import manifest from '@server/domains/dart-inspector/manifest';
+import type { MCPServerContext } from '@server/MCPServer.context';
+import { DartInspectorHandlers } from '@server/domains/dart-inspector/handlers';
+
+function makeMockCtx(): MCPServerContext {
+  return {} as MCPServerContext;
+}
+
+describe('dart-inspector manifest', () => {
+  it('has the correct domain shape', () => {
+    expect(manifest.kind).toBe('domain-manifest');
+    expect(manifest.version).toBe(1);
+    expect(manifest.domain).toBe('dart-inspector');
+    expect(manifest.depKey).toBe('dartInspectorHandlers');
+  });
+
+  it('is only enabled in the full profile (heavy file I/O)', () => {
+    expect(manifest.profiles).toContain('full');
+    expect(manifest.profiles).not.toContain('workflow');
+    expect(manifest.profiles).not.toContain('search');
+  });
+
+  it('registers the dart_strings_extract tool', () => {
+    const toolNames = manifest.registrations.map((r) => r.tool.name);
+    expect(toolNames).toContain('dart_strings_extract');
+    expect(toolNames).toHaveLength(1);
+  });
+
+  it('every registration is bound to the dart-inspector domain', () => {
+    for (const reg of manifest.registrations) {
+      expect(reg.domain).toBe('dart-inspector');
+      expect(typeof reg.bind).toBe('function');
+    }
+  });
+
+  it('ensure() seeds ctx.dartInspectorHandlers and returns the instance', async () => {
+    const ctx = makeMockCtx();
+    const handler = await manifest.ensure(ctx);
+
+    expect(handler).toBeInstanceOf(DartInspectorHandlers);
+    expect(typeof handler.handleDartStringsExtract).toBe('function');
+    expect(ctx.dartInspectorHandlers).toBe(handler);
+  });
+
+  it('ensure() is idempotent — repeat calls return the same instance', async () => {
+    const ctx = makeMockCtx();
+    const first = await manifest.ensure(ctx);
+    const second = await manifest.ensure(ctx);
+    expect(second).toBe(first);
+  });
+});


### PR DESCRIPTION
## Summary

Stack member **3/12** — base: `pr/dart-strings-2-fixtures`.

Wires the `dart_strings_extract` tool end-to-end:
- definitions + handlers
- domain manifest + context slot
- VitePress reference page registration
- integration test against fixture

## Test plan

- [x] integration test that exercises the full handler path
- [x] docs regenerate

## Summary by Sourcery

Add a new dart-inspector domain exposing a dart_strings_extract tool for extracting and classifying strings from Dart/Flutter AOT binaries, and wire it into the server registry and reference docs.

New Features:
- Introduce the dart_strings_extract MCP tool for extracting and classifying strings from libapp.so and other binaries.
- Add the dart-inspector domain manifest, tool definitions, and handlers to integrate the extractor into the MCP server.

Enhancements:
- Register the dart-inspector domain in the global domain registry and server context for discovery in the full profile only.
- Expose the dart-inspector domain and tool in the VitePress reference metadata and domain reference pages in both English and Chinese.

Tests:
- Add unit tests for DartInspectorHandlers covering validation, custom rules, rule modes, and option toggles.
- Add manifest contract tests ensuring correct domain shape, registrations, and ensure() behavior for dart-inspector.
- Add an end-to-end integration test that invokes dart_strings_extract against a tiny libapp.so fixture and validates categorized outputs.