### PR TITLE
fix(screenshot): write CDP screenshot buffer to disk when path is specified

### DIFF
--- a/src/modules/collector/PageController.ts
+++ b/src/modules/collector/PageController.ts
@@ -1,3 +1,4 @@
+import { writeFile } from 'node:fs/promises';
 import type { CodeCollector } from '@modules/collector/CodeCollector';
 import { logger } from '@utils/logger';
 import { PAGE_FRAME_SELECTOR_TIMEOUT_MS, PAGE_NETWORK_IDLE_TIMEOUT_MS } from '@src/constants';
@@ -463,6 +464,9 @@ export class PageController {
           quality: options?.quality,
           clip: options?.clip,
         });
+        if (options?.path) {
+          await writeFile(options.path, buf);
+        }
         logger.info(`Screenshot taken via CDP${options?.path ? `: ${options.path}` : ''}`);
         return buf;
       }


### PR DESCRIPTION
## Summary

- `PageController.screenshot()` silently succeeded without writing any file when a CDP session was active — the captured buffer was returned but never persisted to disk, so callers received a valid buffer but found no file at the specified path.

## What changed

- Added `import { writeFile } from 'node:fs/promises'` to `src/modules/collector/PageController.ts`.
- After `mgr.captureScreenshot()` returns in the CDP branch, conditionally write the buffer to `options.path` when a path is provided — matching the behavior of the non-CDP fallback where `page.screenshot()` handles file writing internally.

## Validation

- Commands run:
  - `npm test` — 54/54 tests pass (vitest, includes `PageController` and `page-evaluation` suites)
  - `pnpm run check` could not run locally (`corepack` not available in this environment); oxfmt and oxlint passed via the pre-commit hook
- Manual end-to-end: called `page_screenshot` via the MCP tool with an explicit path; confirmed the file exists on disk with the expected size (8.3 KB).

## Checklist

- [x] I linked an issue, or explained why one is not needed — this is a self-contained bug fix with clear reproduction and no associated issue.
- [x] I listed the local checks I ran, or explained what I could not run.
- [x] I updated docs if user-facing behavior changed — no user-facing behavior change; file writing now works as documented.

## Related issues

- No existing issue. The bug is reproducible by calling `page_screenshot` with a `path` argument on any page with an active CDP session and observing that no file is created.