### PR TITLE
fix(screenshot): write CDP screenshot buffer to disk when path is specified

### DIFF
--- a/src/modules/collector/PageController.ts
+++ b/src/modules/collector/PageController.ts
@@ -1,3 +1,4 @@
+import { writeFile } from 'node:fs/promises';
 import type { CodeCollector } from '@modules/collector/CodeCollector';
 import { logger } from '@utils/logger';
 import { PAGE_FRAME_SELECTOR_TIMEOUT_MS, PAGE_NETWORK_IDLE_TIMEOUT_MS } from '@src/constants';
@@ -463,6 +464,9 @@ export class PageController {
           quality: options?.quality,
           clip: options?.clip,
         });
+        if (options?.path) {
+          await writeFile(options.path, buf);
+        }
         logger.info(`Screenshot taken via CDP${options?.path ? `: ${options.path}` : ''}`);
         return buf;
       }


### PR DESCRIPTION
## Summary

- When taking a screenshot via CDP, the buffer returned by `captureScreenshot()` was never written to `options.path`. The file was silently not created on disk while the call appeared to succeed.

## What changed

- In `src/modules/collector/PageController.ts`, added `writeFile(options.path, buf)` after the CDP `captureScreenshot()` call, matching the existing non-CDP path behavior.

## Validation

- Commands run:
  - `npm test` — 54/54 tests pass
  - `oxfmt` and `oxlint` passed via pre-commit hook
  - `pnpm run check` could not run (`corepack` unavailable locally)
- Manual test: called `page_screenshot` MCP tool with a path argument; confirmed the file was written to disk (8.3 KB).

## Checklist

- [ ] I linked an issue, or explained why one is not needed.
- [ ] I listed the local checks I ran, or explained what I could not run.
- [ ] I updated docs if user-facing behavior changed.

## Related issues

- No existing issue. Reproducible by calling `page_screenshot` with a `path` on a tab with an active CDP session and checking that no file is created.

## Summary by Sourcery

Bug Fixes:
- Write the CDP screenshot buffer to the specified path so screenshot files are created on disk as expected.