### PR TITLE
feat(encoding): preserve protobuf decode fidelity

### DIFF
--- a/docs/en/reference/domains/encoding.md
+++ b/docs/en/reference/domains/encoding.md
@@ -27,4 +27,4 @@ Binary format detection, encoding conversion, entropy analysis, and raw protobuf
 | `binary_decode` | Decode binary payloads, transport encodings, and compressed blobs into hex, utf8, or json output. |
 | `binary_encode` | Encode utf8/hex/json input into transport encodings or compressed base64 blobs. |
 | `binary_entropy_analysis` | Compute entropy and byte frequency for a payload. |
-| `protobuf_decode_raw` | Decode protobuf bytes. Raw wire-format walk by default (field numbers/wire types); with schemaText/schemaPath + messageName, typed decode via protobufjs (field numbers -&gt; names). |
+| `protobuf_decode_raw` | Decode protobuf bytes. Raw wire-format walk by default; schema mode returns ProtoJSON, expands valid google.protobuf.Any messages, preserves open-enum numeric values, and reports unknown fields with raw bytes plus wire details. |

--- a/src/server/domains/encoding/definitions.ts
+++ b/src/server/domains/encoding/definitions.ts
@@ -85,7 +85,7 @@ export const encodingTools: Tool[] = [
   tool('protobuf_decode_raw', (t) =>
     t
       .desc(
-        'Decode protobuf bytes. Raw wire-format walk by default (field numbers/wire types); with schemaText/schemaPath + messageName, typed decode via protobufjs (field numbers -> names).',
+        'Decode protobuf bytes. Raw wire-format walk by default; schema mode returns ProtoJSON, expands valid google.protobuf.Any messages, preserves open-enum numeric values, and reports unknown fields with raw bytes plus wire details.',
       )
       .string('data', 'Base64-encoded protobuf payload')
       .number('maxDepth', 'Maximum recursive decode depth', { default: 5, minimum: 1, maximum: 20 })

--- a/src/server/domains/encoding/handlers.impl.core.runtime.ts
+++ b/src/server/domains/encoding/handlers.impl.core.runtime.ts
@@ -87,6 +87,26 @@ type ResponseBodyPayload = {
 
 type ResponseBodyResolver = (requestId: string) => Promise<ResponseBodyPayload | null>;
 
+type ProtobufMessageWithUnknowns = {
+  $unknowns?: readonly Uint8Array[];
+};
+
+function summarizeUnknownProtobufFields(message: unknown, maxDepth: number) {
+  const rawFields = (message as ProtobufMessageWithUnknowns).$unknowns ?? [];
+  return rawFields.map((rawField, index) => {
+    const raw = Buffer.from(rawField);
+    const parsed = parseProtobufMessage(raw, 0, maxDepth);
+    return {
+      index,
+      byteLength: raw.length,
+      hex: raw.toString('hex'),
+      base64: raw.toString('base64'),
+      fields: parsed.fields,
+      error: parsed.error ?? null,
+    };
+  });
+}
+
 function decodeDeclaredPayload(encoding: string, data: string): Buffer {
   switch (encoding) {
     case 'base64':
@@ -418,14 +438,30 @@ export class EncodingToolHandlers {
         const root =
           schemaPath && !schemaText
             ? await protobuf.load(schemaPath)
-            : protobuf.parse(schemaText).root;
+            : (() => {
+                const parsed = protobuf.parse(schemaText);
+                for (const importedFile of [
+                  ...(parsed.imports ?? []),
+                  ...(parsed.weakImports ?? []),
+                ]) {
+                  const commonDefinition = protobuf.common.get(importedFile);
+                  if (commonDefinition) {
+                    protobuf.Root.fromJSON(commonDefinition, parsed.root);
+                  }
+                }
+                return parsed.root;
+              })();
+        root.resolveAll();
         const MessageType = root.lookupType(messageName);
-        const message = MessageType.decode(buffer);
+        const reader = protobuf.Reader.create(buffer);
+        reader.discardUnknown = false;
+        const message = MessageType.decode(reader);
         const decoded = MessageType.toObject(message, {
           longs: String,
           bytes: String,
           enums: String,
           defaults: true,
+          json: true,
         });
         return ok({
           success: true,
@@ -433,6 +469,7 @@ export class EncodingToolHandlers {
           messageName,
           byteLength: buffer.length,
           decoded,
+          unknownFields: summarizeUnknownProtobufFields(message, maxDepth),
           fields: null,
           error: null,
         });

--- a/src/server/registry/generated-tool-catalog.ts
+++ b/src/server/registry/generated-tool-catalog.ts
@@ -19895,7 +19895,7 @@ export const GENERATED_TOOL_CATALOG = [
   {
     "tool": {
       "name": "protobuf_decode_raw",
-      "description": "Decode protobuf bytes. Raw wire-format walk by default (field numbers/wire types); with schemaText/schemaPath + messageName, typed decode via protobufjs (field numbers -> names).",
+      "description": "Decode protobuf bytes. Raw wire-format walk by default; schema mode returns ProtoJSON, expands valid google.protobuf.Any messages, preserves open-enum numeric values, and reports unknown fields with raw bytes plus wire details.",
       "inputSchema": {
         "type": "object",
         "properties": {

--- a/tests/server/domains/encoding/runtime.test.ts
+++ b/tests/server/domains/encoding/runtime.test.ts
@@ -643,6 +643,113 @@ describe('EncodingToolHandlers (handlers.impl.core.runtime)', () => {
 
       expect(body.success).toBe(true);
       expect(body.decoded.status).toBe(99);
+      expect(body.unknownFields).toEqual([]);
+    });
+
+    it('reports closed-enum and schema-unknown fields without losing their wire data', async () => {
+      const schema = `
+        syntax = "proto2";
+        message Event {
+          enum Status { UNKNOWN = 0; READY = 1; }
+          optional Status status = 1;
+        }
+      `;
+      const data = Buffer.from([0x08, 0x63, 0x18, 0x07]).toString('base64');
+
+      const body = parseJson<any>(
+        await handlers.handleProtobufDecodeRaw({ data, schemaText: schema, messageName: 'Event' }),
+      );
+
+      expect(body.success).toBe(true);
+      expect(body.decoded.status).toBe('UNKNOWN');
+      expect(body.unknownFields).toHaveLength(2);
+      expect(body.unknownFields[0]).toMatchObject({
+        hex: '0863',
+        base64: 'CGM=',
+        fields: [{ fieldNumber: 1, wireType: 0, value: 99 }],
+        error: null,
+      });
+      expect(body.unknownFields[1]).toMatchObject({
+        hex: '1807',
+        base64: 'GAc=',
+        fields: [{ fieldNumber: 3, wireType: 0, value: 7 }],
+        error: null,
+      });
+    });
+
+    it('expands google.protobuf.Any message values in ProtoJSON output', async () => {
+      const protobuf = (await import('protobufjs')).default;
+      const schema = `
+        syntax = "proto3";
+        package demo;
+        import "google/protobuf/any.proto";
+        message Payload { string name = 1; }
+        message Envelope { google.protobuf.Any payload = 1; }
+      `;
+      const root = protobuf.Root.fromJSON(protobuf.common.get('google/protobuf/any.proto')!);
+      protobuf.parse(schema, root);
+      root.resolveAll();
+      const Payload = root.lookupType('demo.Payload');
+      const Envelope = root.lookupType('demo.Envelope');
+      const data = Buffer.from(
+        Envelope.encode({
+          payload: {
+            type_url: 'type.googleapis.com/demo.Payload',
+            value: Payload.encode({ name: 'Alice' }).finish(),
+          },
+        }).finish(),
+      ).toString('base64');
+
+      const body = parseJson<any>(
+        await handlers.handleProtobufDecodeRaw({
+          data,
+          schemaText: schema,
+          messageName: 'demo.Envelope',
+        }),
+      );
+
+      expect(body.success).toBe(true);
+      expect(body.decoded.payload).toEqual({
+        name: 'Alice',
+        '@type': 'type.googleapis.com/demo.Payload',
+      });
+    });
+
+    it('does not expand Any type URLs that resolve to non-message schema objects', async () => {
+      const protobuf = (await import('protobufjs')).default;
+      const schema = `
+        syntax = "proto3";
+        package demo;
+        import "google/protobuf/any.proto";
+        enum Status { UNKNOWN = 0; }
+        message Envelope { google.protobuf.Any payload = 1; }
+      `;
+      const root = protobuf.Root.fromJSON(protobuf.common.get('google/protobuf/any.proto')!);
+      protobuf.parse(schema, root);
+      root.resolveAll();
+      const Envelope = root.lookupType('demo.Envelope');
+      const data = Buffer.from(
+        Envelope.encode({
+          payload: {
+            type_url: 'type.googleapis.com/demo.Status',
+            value: Buffer.from([0x00]),
+          },
+        }).finish(),
+      ).toString('base64');
+
+      const body = parseJson<any>(
+        await handlers.handleProtobufDecodeRaw({
+          data,
+          schemaText: schema,
+          messageName: 'demo.Envelope',
+        }),
+      );
+
+      expect(body.success).toBe(true);
+      expect(body.decoded.payload).toEqual({
+        type_url: 'type.googleapis.com/demo.Status',
+        value: 'AA==',
+      });
     });
 
     it('falls back to raw wire-format when no schema/messageName given', async () => {


### PR DESCRIPTION
## Summary
- preserve and expose unknown protobuf wire fields, including proto2 closed-enum values
- resolve inline schemas with bundled well-known imports and expand valid google.protobuf.Any messages as ProtoJSON
- retain proto3 open-enum numeric values and leave non-message Any targets unexpanded

## Verification
- pnpm exec vitest run tests/server/domains/encoding/runtime.test.ts tests/contracts/security-overrides.test.ts (75 passed)
- pnpm typecheck
- pnpm lint
- pnpm format:check
- pnpm build
- pnpm run metadata:check
- pnpm test (17,379 passed; 2 failures caused by a pre-existing uncommitted NetworkMonitor change outside this PR)

## Summary by Sourcery

Improve protobuf schema-based decoding to preserve unknown wire fields and expand well-known Any message payloads while maintaining ProtoJSON output fidelity.

New Features:
- Expose unknown protobuf wire fields from decoded messages, including their raw bytes and parsed wire details.
- Automatically expand valid google.protobuf.Any message values into embedded ProtoJSON when the target type is a message.

Enhancements:
- Ensure schema-based protobuf decoding uses ProtoJSON output, preserves proto3 open-enum numeric values, and retains raw unknown field data.
- Augment protobuf schema resolution to load bundled well-known type definitions referenced via imports.
- Document the enhanced behavior of the protobuf_decode_raw tool to reflect ProtoJSON output, Any expansion, and unknown field reporting.

Tests:
- Add runtime tests covering unknown field reporting, Any message expansion, and non-message Any targets remaining unexpanded.