### PR TITLE
fix(deps): pin mockttp to 4.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "dotenv": "^17.4.2",
     "jsdom": "^29.1.1",
     "koffi": "^3.0.2",
-    "mockttp": "^4.4.2",
+    "mockttp": "4.4.2",
     "protobufjs": "8.6.6",
     "quickjs-emscripten": "^0.32.0",
     "rebrowser-puppeteer-core": "^24.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,7 +60,7 @@ importers:
         specifier: ^3.0.2
         version: 3.0.2
       mockttp:
-        specifier: ^4.4.2
+        specifier: 4.4.2
         version: 4.4.2
       protobufjs:
         specifier: 8.6.6


### PR DESCRIPTION
## Summary

- pin `mockttp` at 4.4.2 instead of allowing caret-range updates
- preserve the Node 22-compatible dependency graph used by `webcrack -> isolated-vm -> node-gyp-build`
- prevent an automatic move to mockttp 4.5.x, whose optional `tls-impersonate` dependency requires Node >=24.15.0 and breaks fresh Node 22 installs in the grouped #86 graph

The lockfile keeps the existing mockttp 4.4.2 resolution; this PR changes only the declared specifier.

## Verification

- Node 22.22.2 frozen install
- webcrack benchmark suite (33 passed)
- `pnpm check` (17,326 passed, 55 skipped)
- `pnpm build`
- pre-push coverage gate (82.89% statements, 73.13% branches)

## Summary by Sourcery

Build:
- Update package.json to use an exact mockttp 4.4.2 dependency specifier instead of a caret range.