### PR TITLE
fix: restore broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,11 +101,11 @@ The built-in surface below is generated from the runtime registry and checked in
 
 <div align="center">
 
-<a href="https://www.star-history.com/?repos=vmoranv%2Fjshookmcp&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#vmoranv/jshookmcp&type=date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/image?repos=vmoranv/jshookmcp&type=date&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/image?repos=vmoranv/jshookmcp&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/image?repos=vmoranv/jshookmcp&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/image?repos=vmoranv/jshookmcp&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/image?repos=vmoranv/jshookmcp&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/image?repos=vmoranv/jshookmcp&type=date&legend=top-left" />
  </picture>
 </a>
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -101,11 +101,11 @@ pnpm daemon
 
 <div align="center">
 
-<a href="https://www.star-history.com/?repos=vmoranv%2Fjshookmcp&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#vmoranv/jshookmcp&type=date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/image?repos=vmoranv/jshookmcp&type=date&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/image?repos=vmoranv/jshookmcp&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/image?repos=vmoranv/jshookmcp&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/image?repos=vmoranv/jshookmcp&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/image?repos=vmoranv/jshookmcp&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/image?repos=vmoranv/jshookmcp&type=date&legend=top-left" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the README is broken and no longer renders because of GitHub stargazer API restrictions. This switches the chart links and images to a working alternative so the chart displays again. Updated in both the English and Chinese READMEs.

## Summary by Sourcery

Restore README star history chart rendering with a working alternative service.

Bug Fixes:
- Restore the star history chart in both English and Chinese README files by switching to a working chart service.

Documentation:
- Update the English and Chinese README star history chart links and image sources.