### PR TITLE
feat(response): MCP 2.0 blobResource / audio content builders

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "@babel/traverse": "^8.0.0",
     "@babel/types": "^8.0.0",
     "@huggingface/tokenizers": "^0.1.3",
-    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "@msgpack/msgpack": "^3.1.3",
     "diff": "^9.0.0",
     "dns-packet": "^5.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,8 +52,8 @@ importers:
         specifier: ^0.1.3
         version: 0.1.3
       '@modelcontextprotocol/sdk':
-        specifier: ^1.29.0
-        version: 1.29.0(zod@4.4.3)
+        specifier: ^1.30.0
+        version: 1.30.0(zod@4.4.3)
       '@msgpack/msgpack':
         specifier: ^3.1.3
         version: 3.1.3
@@ -738,6 +738,16 @@ packages:
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+
+  '@modelcontextprotocol/sdk@1.30.0':
+    resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
@@ -4630,6 +4640,28 @@ snapshots:
   '@leichtgewicht/ip-codec@2.0.5': {}
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 2.0.12(hono@4.12.32)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.3.0(express@5.2.1)
+      hono: 4.12.32
+      jose: 6.2.2
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@modelcontextprotocol/sdk@1.30.0(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 2.0.12(hono@4.12.32)
       ajv: 8.18.0

--- a/src/server/domains/shared/ResponseBuilder.ts
+++ b/src/server/domains/shared/ResponseBuilder.ts
@@ -1,11 +1,19 @@
 import type { ToolResponse } from '@server/types';
 import type {
-  ImageContent,
+  AudioContent,
+  BlobResourceContents,
   EmbeddedResource,
+  ImageContent,
   TextContent,
 } from '@modelcontextprotocol/sdk/types.js';
 
 export type { ToolResponse };
+
+export type AdditionalContentBlock =
+  | ImageContent
+  | AudioContent
+  | EmbeddedResource
+  | { type: 'resource'; resource: BlobResourceContents };
 
 /**
  * Fluent builder for MCP tool responses.
@@ -23,7 +31,7 @@ export type { ToolResponse };
 export class ResponseBuilder {
   private payload: Record<string, unknown> = {};
   private hasMcpError = false;
-  private additionalContent: (ImageContent | EmbeddedResource)[] = [];
+  private additionalContent: AdditionalContentBlock[] = [];
   private useStructuredContent = false;
 
   /** Mark as success (sets `success: true`). */
@@ -78,6 +86,29 @@ export class ResponseBuilder {
         text,
         mimeType,
       },
+    });
+    return this;
+  }
+
+  /** Push a binary blob resource block (MCP 2.0 / 2025-11-25 BlobResourceContents). */
+  blobResource(uri: string, base64Blob: string, mimeType = 'application/octet-stream'): this {
+    this.additionalContent.push({
+      type: 'resource',
+      resource: {
+        uri,
+        blob: base64Blob,
+        mimeType,
+      },
+    });
+    return this;
+  }
+
+  /** Push an audio content block (MCP 2.0 / 2025-11-25 AudioContent). */
+  audio(base64Data: string, mimeType = 'audio/wav'): this {
+    this.additionalContent.push({
+      type: 'audio',
+      data: base64Data,
+      mimeType,
     });
     return this;
   }

--- a/tests/server/domains/shared/responseBuilder.test.ts
+++ b/tests/server/domains/shared/responseBuilder.test.ts
@@ -82,6 +82,26 @@ describe('ResponseBuilder', () => {
       expect((res.content[1] as any).resource.text).toBe('test content');
       expect((res.content[1] as any).resource.mimeType).toBe('text/plain');
     });
+
+    it('should support .blobResource() binary blocks (MCP 2.0 BlobResourceContents)', async () => {
+      const res = new ResponseBuilder()
+        .blobResource('jshook://capture.pcap', 'dGVzdGJsb2I=', 'application/vnd.tcpdump.pcap')
+        .json();
+      expect(res.content).toHaveLength(2);
+      expect((res.content[1] as any).resource.uri).toBe('jshook://capture.pcap');
+      expect((res.content[1] as any).resource.blob).toBe('dGVzdGJsb2I=');
+      expect((res.content[1] as any).resource.mimeType).toBe('application/vnd.tcpdump.pcap');
+    });
+
+    it('should support .audio() content blocks (MCP 2.0 AudioContent)', async () => {
+      const res = new ResponseBuilder().audio('YXVkaW9kYXRh', 'audio/wav').json();
+      expect(res.content).toHaveLength(2);
+      expect(res.content[1]).toEqual({
+        type: 'audio',
+        data: 'YXVkaW9kYXRh',
+        mimeType: 'audio/wav',
+      });
+    });
   });
 
   describe('R shorthand', () => {


### PR DESCRIPTION
Stack 1/6 (merge first). Adds `ResponseBuilder.blobResource(uri, blob, mime)` and `.audio(data, mime)` (MCP 2.0 `BlobResourceContents` / `AudioContent`) plus 2 tests. ~88 lines. Next PR in stack: #2 tasks scheduler.

## Summary by Sourcery

Enable ResponseBuilder to emit MCP 2.0 binary resource and audio content responses.

New Features:
- Add fluent builders for MCP binary blob resources and audio content blocks with configurable MIME types.

Enhancements:
- Expand response content typing to support audio and binary resource blocks.

Build:
- Upgrade the MCP SDK dependency to version 1.30.0.

Tests:
- Add coverage for blob resource and audio response content generation.