### PR TITLE
feat(browser): captcha manual-mode suspend/resume via elicitation requestState

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,9 @@ MCP_AUTH_TOKEN=
 # MCP_LOG_LEVEL=info
 # MCP_LOG_FILE_DIR=
 
+# ── MRTR requestState (ElicitationBridge suspend/resume) ──────────────
+# Secret for encrypted MRTR requestState tokens (>= 16 chars, multi-instance only)
+MCP_REQUEST_STATE_SECRET=
 # ── Extension / workflow discovery ─────────────────────────────────────
 EXTENSION_REGISTRY_BASE_URL=
 # Public registry URL: https://raw.githubusercontent.com/vmoranv/jshookmcpextension/master/registry

--- a/src/server/ElicitationBridge.ts
+++ b/src/server/ElicitationBridge.ts
@@ -16,8 +16,11 @@ import type {
   ElicitRequestFormParams,
   PrimitiveSchemaDefinition,
 } from '@modelcontextprotocol/sdk/types.js';
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from 'node:crypto';
 import { logger } from '@utils/logger';
 import { getToolRequestContext } from '@server/runtime/ToolRequestContext';
+import { R, type ToolResponse } from '@server/domains/shared/ResponseBuilder';
+import { readEnvNullableString } from '@src/config/environment';
 
 /** Result of an elicitation request */
 export interface ElicitationResult {
@@ -30,6 +33,52 @@ export interface ElicitationResult {
   action: 'accept' | 'decline' | 'dismiss';
   /** Form field values (only present when action === 'accept' and mode === 'form') */
   content?: Record<string, unknown>;
+}
+
+/** One pending input request inside an InputRequiredResult suspension (MRTR). */
+export interface InputRequiredRequest {
+  type: 'form';
+  message: string;
+  requestedSchema: ElicitRequestFormParams['requestedSchema'];
+}
+
+/**
+ * MRTR-style suspension envelope — returned by tools that need input when the
+ * connected client cannot elicit inline. The client completes the flow by
+ * re-calling the tool with `resumeToken` (= requestState) and the responses.
+ */
+export interface InputRequiredSuspension {
+  resultType: 'input_required';
+  inputRequests: InputRequiredRequest[];
+  requestState: string;
+  instruction?: string;
+}
+
+/** Decrypted payload of a requestState token. */
+export interface RequestStateContents<T = Record<string, unknown>> {
+  kind: string;
+  data: T;
+}
+
+// ── Encrypted requestState codec (AES-256-GCM) ──
+
+let processStateKey: Buffer | null = null;
+
+/**
+ * Server-side key material for requestState tokens. `MCP_REQUEST_STATE_SECRET`
+ * (>= 16 chars) enables multi-instance deployments; otherwise a per-process
+ * random key is used — tokens are round-trip state, not persistent storage,
+ * so a process restart invalidating outstanding tokens is acceptable.
+ */
+function getRequestStateKey(): Buffer {
+  const envSecret = readEnvNullableString('MCP_REQUEST_STATE_SECRET');
+  if (envSecret && envSecret.length >= 16) {
+    return createHash('sha256').update(envSecret).digest();
+  }
+  if (!processStateKey) {
+    processStateKey = randomBytes(32);
+  }
+  return processStateKey;
 }
 
 export class ElicitationBridge {
@@ -162,5 +211,176 @@ export class ElicitationBridge {
       solved: result.content?.solved === true,
       token: typeof result.content?.token === 'string' ? result.content.token : undefined,
     };
+  }
+
+  // ── MRTR (InputRequiredResult) support ──
+
+  /**
+   * Encrypt an arbitrary state payload into an opaque `requestState` token.
+   * The token round-trips through the client without the client being able to
+   * read or tamper with it (AES-256-GCM). Tokens expire after `ttlMs`
+   * (default 10 minutes).
+   */
+  createRequestState<T extends Record<string, unknown>>(
+    data: T,
+    opts: { ttlMs?: number; kind?: string } = {},
+  ): string {
+    const iv = randomBytes(12);
+    const cipher = createCipheriv('aes-256-gcm', getRequestStateKey(), iv);
+    const plaintext = Buffer.from(
+      JSON.stringify({
+        kind: opts.kind ?? 'generic',
+        exp: Date.now() + (opts.ttlMs ?? 10 * 60_000),
+        data,
+      }),
+      'utf8',
+    );
+    const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+    const tag = cipher.getAuthTag();
+    return [
+      'v1',
+      iv.toString('base64url'),
+      tag.toString('base64url'),
+      ciphertext.toString('base64url'),
+    ].join('.');
+  }
+
+  /**
+   * Decrypt and verify a `requestState` token produced by
+   * {@link createRequestState}. Returns `null` for tampered, malformed or
+   * expired tokens — callers treat that as "suspension no longer resumable".
+   */
+  readRequestState<T extends Record<string, unknown> = Record<string, unknown>>(
+    token: string,
+  ): RequestStateContents<T> | null {
+    try {
+      const [version, ivB64, tagB64, ctB64] = token.split('.');
+      if (version !== 'v1' || !ivB64 || !tagB64 || !ctB64) return null;
+      const decipher = createDecipheriv(
+        'aes-256-gcm',
+        getRequestStateKey(),
+        Buffer.from(ivB64, 'base64url'),
+      );
+      decipher.setAuthTag(Buffer.from(tagB64, 'base64url'));
+      const plaintext = Buffer.concat([
+        decipher.update(Buffer.from(ctB64, 'base64url')),
+        decipher.final(),
+      ]);
+      const parsed = JSON.parse(plaintext.toString('utf8')) as {
+        kind: string;
+        exp: number;
+        data: T;
+      };
+      if (typeof parsed.exp !== 'number' || parsed.exp < Date.now()) return null;
+      return { kind: parsed.kind, data: parsed.data };
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Build an MRTR-style `InputRequiredResult` suspension envelope. Embeds the
+   * form params + caller context into the encrypted requestState so the flow
+   * can resume on a later tool call without trusting client-side storage.
+   */
+  buildInputRequiredSuspension(
+    formParams: ElicitRequestFormParams,
+    state: Record<string, unknown> = {},
+    opts: { ttlMs?: number; kind?: string; instruction?: string } = {},
+  ): InputRequiredSuspension {
+    const requestState = this.createRequestState(
+      { formParams, ...state },
+      { ttlMs: opts.ttlMs ?? 10 * 60_000, kind: opts.kind ?? 'input_required' },
+    );
+    return {
+      resultType: 'input_required',
+      inputRequests: [
+        {
+          type: 'form',
+          message: formParams.message,
+          requestedSchema: formParams.requestedSchema,
+        },
+      ],
+      requestState,
+      ...(opts.instruction ? { instruction: opts.instruction } : {}),
+    };
+  }
+
+  /** True when a tool response is an {@link InputRequiredSuspension} envelope. */
+  isInputRequiredSuspension(response: ToolResponse): boolean {
+    try {
+      const parsed = R.parse<Record<string, unknown>>(response);
+      return parsed['resultType'] === 'input_required';
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Wrap a suspension envelope into a ToolResponse.
+   */
+  suspensionToResponse(suspension: InputRequiredSuspension): ToolResponse {
+    return R.ok()
+      .merge({ ...suspension })
+      .json();
+  }
+
+  /**
+   * Decrypt a requestState token for a resuming tool call.
+   * Returns the original form params plus the caller-embedded state, or null.
+   */
+  resumeFromState<T extends Record<string, unknown> = Record<string, unknown>>(
+    token: string,
+    expectedKind?: string,
+  ): { formParams: ElicitRequestFormParams; state: RequestStateContents<T> } | null {
+    const contents = this.readRequestState<{ formParams?: ElicitRequestFormParams } & T>(token);
+    if (!contents) return null;
+    if (expectedKind && contents.kind !== expectedKind) return null;
+    if (!contents.data?.formParams) return null;
+    const { formParams, ...rest } = contents.data;
+    return { formParams: formParams!, state: { ...contents, data: rest as T } };
+  }
+
+  /**
+   * MRTR-style suspend-and-resume wrapper (plan Task 3.1 API).
+   *
+   * - Client supports elicitation: sends the form inline and resumes
+   *   `executor` with the responses; decline/dismiss fails the response.
+   * - Client does NOT support elicitation: returns an InputRequiredResult
+   *   suspension envelope carrying an encrypted requestState — the flow is
+   *   resumed later by re-calling the tool with `resumeToken`.
+   */
+  async requestInputAndAwait(
+    formParams: ElicitRequestFormParams,
+    executor: (
+      responses: Record<string, unknown>,
+      result: ElicitationResult,
+    ) => Promise<ToolResponse>,
+    opts: {
+      stateTtlMs?: number;
+      stateKind?: string;
+      instruction?: string;
+      /** Extra context embedded (encrypted) into the requestState for the resuming call. */
+      state?: Record<string, unknown>;
+    } = {},
+  ): Promise<ToolResponse> {
+    const result = await this.requestFormInput(formParams);
+
+    if (result) {
+      if (result.action !== 'accept') {
+        return R.fail(`Input request was ${result.action}d by the user.`)
+          .set('inputResult', result.action)
+          .json();
+      }
+      return executor(result.content ?? {}, result);
+    }
+
+    return this.suspensionToResponse(
+      this.buildInputRequiredSuspension(formParams, opts.state ?? {}, {
+        ttlMs: opts.stateTtlMs,
+        kind: opts.stateKind,
+        instruction: opts.instruction,
+      }),
+    );
   }
 }

--- a/src/server/domains/browser/handlers.impl.ts
+++ b/src/server/domains/browser/handlers.impl.ts
@@ -123,6 +123,8 @@ export class BrowserToolHandlers {
   private readonly getCurrentSessionId?: () => string | null;
   private readonly sessionCoordinator?: BrowserSessionCoordinator;
   private readonly fleetRouter?: BrowserFleetRouter;
+  /** Elicitation bridge — powers the CAPTCHA manual-solve suspend/resume flow. */
+  private readonly elicitationBridge?: import('@server/ElicitationBridge').ElicitationBridge;
   private readonly onBrowserAttachStateChanged?: (
     snapshot: Partial<BrowserAttachRuntimeSnapshot>,
   ) => void;
@@ -140,6 +142,7 @@ export class BrowserToolHandlers {
     sessionCoordinator?: BrowserSessionCoordinator,
     onBrowserAttachStateChanged?: (snapshot: Partial<BrowserAttachRuntimeSnapshot>) => void,
     fleetRouter?: BrowserFleetRouter,
+    elicitationBridge?: import('@server/ElicitationBridge').ElicitationBridge,
   ) {
     this.collector = collector;
     this.pageController = pageController;
@@ -151,6 +154,7 @@ export class BrowserToolHandlers {
     this.sessionCoordinator = sessionCoordinator;
     this.fleetRouter = fleetRouter;
     this.onBrowserAttachStateChanged = onBrowserAttachStateChanged;
+    this.elicitationBridge = elicitationBridge;
 
     const screenshotDir = resolveOutputDirectory(
       getConfig().paths.captchaScreenshotDir,
@@ -907,7 +911,7 @@ export class BrowserToolHandlers {
 
   // ── CAPTCHA Solving ──
   async handleCaptchaVisionSolve(args: Record<string, unknown>) {
-    return handleCaptchaVisionSolve(args, this.collector);
+    return handleCaptchaVisionSolve(args, this.collector, this.elicitationBridge);
   }
 
   async handleWidgetChallengeSolve(args: Record<string, unknown>) {

--- a/src/server/domains/browser/handlers/captcha-solver.ts
+++ b/src/server/domains/browser/handlers/captcha-solver.ts
@@ -9,6 +9,11 @@ import { argString, argNumber, argBool } from '@server/domains/shared/parse-args
 import { logger } from '@utils/logger';
 import { fetchWithTimeout } from '@utils/network/fetch';
 import { R, type ToolResponse } from '@server/domains/shared/ResponseBuilder';
+import type { ElicitationBridge } from '@server/ElicitationBridge';
+import type {
+  ElicitRequestFormParams,
+  PrimitiveSchemaDefinition,
+} from '@modelcontextprotocol/sdk/types.js';
 import { readEnvNullableString, readEnvString } from '@src/config/environment';
 import {
   CAPTCHA_SOLVER_BASE_URL,
@@ -451,6 +456,7 @@ async function solveWith2Captcha(
 export async function handleCaptchaVisionSolve(
   args: Record<string, unknown>,
   collector: CodeCollector,
+  elicitationBridge?: ElicitationBridge,
 ): Promise<ToolResponse> {
   const page = await collector.getActivePage();
   if (!page) return R.fail('No active page.').build();
@@ -476,11 +482,103 @@ export async function handleCaptchaVisionSolve(
   const siteKey = argString(args, 'siteKey');
   const pageUrl = argString(args, 'pageUrl', '') || page.url();
 
-  if (requiresWidgetContext(taskKind) && !siteKey) {
+  // Widget solving needs a siteKey for external providers, but manual mode
+  // delegates the solving to the user in-browser, so it may proceed without one.
+  if (requiresWidgetContext(taskKind) && !siteKey && mode !== 'manual') {
     return R.fail('Widget solving requires an explicit siteKey.').build();
   }
 
   if (mode === 'manual') {
+    // ── Resume path (MRTR round-trip): the client re-calls this tool with the
+    // requestState token returned by a previous suspension + user responses.
+    const resumeToken = argString(args, 'resumeToken');
+    if (resumeToken && elicitationBridge) {
+      const decoded = elicitationBridge.resumeFromState<{
+        pageUrl?: string;
+        challengeType?: string;
+      }>(resumeToken, 'captcha_manual');
+      if (!decoded) {
+        return R.fail(
+          'resumeToken is invalid, expired or from a different flow. Restart with a fresh captcha_vision_solve call.',
+        ).build();
+      }
+      const responses = (args.resumeResponses ?? {}) as Record<string, unknown>;
+      if (responses.solved !== true) {
+        return R.fail('User indicated the CAPTCHA is not solved.')
+          .set('inputResult', responses.solved === false ? 'declined' : 'incomplete')
+          .build();
+      }
+      return R.ok().build({
+        mode: 'manual',
+        resumed: true,
+        solved: true,
+        token: typeof responses.token === 'string' ? responses.token : undefined,
+        challengeType: decoded.state.data.challengeType ?? challengeType,
+        pageUrl: decoded.state.data.pageUrl ?? pageUrl,
+      });
+    }
+
+    // ── Suspend path: interactive elicitation when the client supports it,
+    // otherwise an InputRequiredResult suspension with an encrypted
+    // requestState (plan Task 3.2 — CAPTCHA ↔ ElicitationBridge linkage).
+    if (elicitationBridge) {
+      const manualForm: ElicitRequestFormParams = {
+        message: [
+          `🛡️ CAPTCHA detected: **${challengeType}**`,
+          '',
+          `Page: ${pageUrl}`,
+          '',
+          'Please solve the CAPTCHA in your browser, then confirm below.',
+          'If a response token was generated, paste it in the token field.',
+        ].join('\n'),
+        requestedSchema: {
+          type: 'object',
+          properties: {
+            solved: {
+              type: 'boolean',
+              description: 'Have you solved the CAPTCHA?',
+              title: 'CAPTCHA Solved',
+              default: false,
+            } satisfies PrimitiveSchemaDefinition,
+            token: {
+              type: 'string',
+              description: 'CAPTCHA response token (if available)',
+              title: 'Response Token',
+            } satisfies PrimitiveSchemaDefinition,
+          },
+          required: ['solved'],
+        },
+      };
+
+      return elicitationBridge.requestInputAndAwait(
+        manualForm,
+        async (responses) => {
+          if (responses.solved !== true) {
+            return R.fail('User indicated the CAPTCHA is not solved.')
+              .set('inputResult', 'declined')
+              .build();
+          }
+          return R.ok().build({
+            mode: 'manual',
+            resumed: true,
+            solved: true,
+            token: typeof responses.token === 'string' ? responses.token : undefined,
+            challengeType,
+            pageUrl,
+          });
+        },
+        {
+          stateKind: 'captcha_manual',
+          stateTtlMs: 10 * 60_000,
+          state: { challengeType, pageUrl },
+          instruction:
+            'Re-call captcha_vision_solve with mode=manual, resumeToken=<requestState> and ' +
+            'resumeResponses={ solved: true, token? } after the user solves the CAPTCHA.',
+        },
+      );
+    }
+
+    // Legacy behavior — no elicitation bridge available (e.g. unit tests).
     return R.ok().build({
       mode: 'manual',
       challengeType,

--- a/src/server/domains/browser/manifest.ts
+++ b/src/server/domains/browser/manifest.ts
@@ -139,6 +139,7 @@ async function ensure(ctx: MCPServerContext): Promise<H> {
         getRuntimeState(ctx)?.setBrowserAttach(snapshot);
       },
       getDomainInstance?.<BrowserFleetRouter>('browserFleetRouter'),
+      ctx.elicitationBridge,
     );
   }
   return ctx.browserHandlers;

--- a/tests/server/domains/browser/captcha-manual-mrtr.test.ts
+++ b/tests/server/domains/browser/captcha-manual-mrtr.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it, vi } from 'vitest';
+import { handleCaptchaVisionSolve } from '@server/domains/browser/handlers/captcha-solver';
+import { ElicitationBridge } from '@server/ElicitationBridge';
+import { R } from '@server/domains/shared/ResponseBuilder';
+import { buildTestUrl } from '@tests/shared/test-urls';
+import type { CodeCollector } from '@server/domains/shared/modules/collector';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+function parse(res: Parameters<typeof R.parse>[0]): Record<string, unknown> {
+  return R.parse<Record<string, unknown>>(res);
+}
+
+function makeCollector(pageUrl: string): CodeCollector {
+  return {
+    getActivePage: vi.fn(async () => ({ url: () => pageUrl })),
+  } as unknown as CodeCollector;
+}
+
+function makeBridge(elicitationSupported: boolean, elicitResult?: unknown): ElicitationBridge {
+  const mcpServer = {
+    server: {
+      getClientCapabilities: vi.fn(() => ({
+        elicitation: elicitationSupported ? {} : undefined,
+      })),
+      elicitInput: vi.fn(async () => elicitResult ?? { action: 'accept', content: {} }),
+    },
+  } as unknown as McpServer;
+  return new ElicitationBridge(mcpServer);
+}
+
+describe('handleCaptchaVisionSolve — manual mode MRTR linkage (plan Task 3.2)', () => {
+  it('suspends with InputRequiredResult when the client cannot elicit inline', async () => {
+    const bridge = makeBridge(false);
+    const res = parse(
+      await handleCaptchaVisionSolve(
+        { mode: 'manual', challengeType: 'widget', siteKey: 'sk-1' },
+        makeCollector(buildTestUrl('protected', { path: '/login' })),
+        bridge,
+      ),
+    );
+
+    expect(res.success).toBe(true);
+    expect(res.resultType).toBe('input_required');
+    expect(Array.isArray(res.inputRequests)).toBe(true);
+    expect(typeof res.requestState).toBe('string');
+    expect(String(res.instruction)).toContain('resumeToken');
+
+    // The encrypted state carries the challenge context for the resuming call.
+    const decoded = bridge.resumeFromState<{ challengeType?: string; pageUrl?: string }>(
+      res.requestState as string,
+      'captcha_manual',
+    );
+    expect(decoded?.state.data.challengeType).toBe('widget');
+    expect(decoded?.state.data.pageUrl).toBe(buildTestUrl('protected', { path: '/login' }));
+  });
+
+  it('resumes a suspension when called back with a valid resumeToken', async () => {
+    const bridge = makeBridge(false);
+    const suspended = parse(
+      await handleCaptchaVisionSolve(
+        { mode: 'manual', challengeType: 'widget' },
+        makeCollector(buildTestUrl('protected', { path: '/login' })),
+        bridge,
+      ),
+    );
+
+    const resumed = parse(
+      await handleCaptchaVisionSolve(
+        {
+          mode: 'manual',
+          resumeToken: suspended.requestState,
+          resumeResponses: { solved: true, token: 'cf-turnstile-response' },
+        },
+        makeCollector(buildTestUrl('protected', { path: '/login' })),
+        bridge,
+      ),
+    );
+
+    expect(resumed.success).toBe(true);
+    expect(resumed.resumed).toBe(true);
+    expect(resumed.solved).toBe(true);
+    expect(resumed.token).toBe('cf-turnstile-response');
+  });
+
+  it('rejects resumption when the user reports the CAPTCHA unsolved', async () => {
+    const bridge = makeBridge(false);
+    const suspended = parse(
+      await handleCaptchaVisionSolve(
+        { mode: 'manual' },
+        makeCollector(buildTestUrl('protected', { path: '/login' })),
+        bridge,
+      ),
+    );
+
+    const resumed = parse(
+      await handleCaptchaVisionSolve(
+        {
+          mode: 'manual',
+          resumeToken: suspended.requestState,
+          resumeResponses: { solved: false },
+        },
+        makeCollector(buildTestUrl('protected', { path: '/login' })),
+        bridge,
+      ),
+    );
+
+    expect(resumed.success).toBe(false);
+  });
+
+  it('refuses invalid or foreign-kind resumeTokens', async () => {
+    const bridge = makeBridge(false);
+    const res = parse(
+      await handleCaptchaVisionSolve(
+        { mode: 'manual', resumeToken: 'v1.tampered.token.here' },
+        makeCollector(buildTestUrl('protected', { path: '/login' })),
+        bridge,
+      ),
+    );
+    expect(res.success).toBe(false);
+    expect(String(res.error)).toContain('resumeToken');
+  });
+
+  it('uses inline elicitation when the client supports it and resumes with user responses', async () => {
+    const bridge = makeBridge(true, {
+      action: 'accept',
+      content: { solved: true, token: 'inline-token' },
+    });
+    const res = parse(
+      await handleCaptchaVisionSolve(
+        { mode: 'manual', challengeType: 'image' },
+        makeCollector(buildTestUrl('protected', { path: '/login' })),
+        bridge,
+      ),
+    );
+
+    expect(res.success).toBe(true);
+    expect(res.resumed).toBe(true);
+    expect(res.token).toBe('inline-token');
+    expect(res.resultType).toBeUndefined();
+  });
+
+  it('keeps the legacy manual response when no elicitation bridge is available', async () => {
+    const res = parse(
+      await handleCaptchaVisionSolve(
+        { mode: 'manual', challengeType: 'image' },
+        makeCollector(buildTestUrl('protected', { path: '/login' })),
+      ),
+    );
+
+    expect(res.success).toBe(true);
+    expect(res.mode).toBe('manual');
+    expect(res.instruction).toContain('manually');
+    expect(res.resultType).toBeUndefined();
+  });
+});

--- a/tests/server/elicitationBridge.mrtr.test.ts
+++ b/tests/server/elicitationBridge.mrtr.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ElicitationBridge } from '@server/ElicitationBridge';
+import { R } from '@server/domains/shared/ResponseBuilder';
+import { buildTestUrl } from '@tests/shared/test-urls';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+function makeBridge(opts: { elicitationSupported?: boolean; elicitResult?: unknown } = {}) {
+  const mcpServer = {
+    server: {
+      getClientCapabilities: vi.fn(() => ({
+        elicitation: opts.elicitationSupported ? {} : undefined,
+      })),
+      elicitInput: vi.fn(async () => opts.elicitResult ?? { action: 'accept', content: {} }),
+    },
+  } as unknown as McpServer;
+  return { bridge: new ElicitationBridge(mcpServer), mcpServer };
+}
+
+describe('ElicitationBridge — MRTR (InputRequiredResult) support', () => {
+  it('requestState round-trips the payload intact', () => {
+    const { bridge } = makeBridge();
+    const token = bridge.createRequestState(
+      { tool: 'captcha_vision_solve', pageUrl: buildTestUrl('x') },
+      { kind: 'captcha_manual', ttlMs: 60_000 },
+    );
+    expect(token).toMatch(/^v1\./);
+
+    const decoded = bridge.readRequestState<{ tool: string; pageUrl: string }>(token);
+    expect(decoded?.kind).toBe('captcha_manual');
+    expect(decoded?.data.tool).toBe('captcha_vision_solve');
+    expect(decoded?.data.pageUrl).toBe(buildTestUrl('x'));
+  });
+
+  it('requestState rejects tampered ciphertext and wrong version prefixes', () => {
+    const { bridge } = makeBridge();
+    const token = bridge.createRequestState({ a: 1 });
+    const [version, iv, tag, ct] = token.split('.');
+    expect(version).toBe('v1');
+
+    const flipped = Buffer.from(ct!, 'base64url');
+    flipped[0] = flipped[0]! ^ 0xff;
+    const tampered = [version, iv, tag, flipped.toString('base64url')].join('.');
+    expect(bridge.readRequestState(tampered)).toBeNull();
+    expect(bridge.readRequestState('bogus-token')).toBeNull();
+    expect(bridge.readRequestState('v2.aaa.bbb.ccc')).toBeNull();
+  });
+
+  it('expired requestState tokens are refused', () => {
+    const { bridge } = makeBridge();
+    const token = bridge.createRequestState({ a: 1 }, { ttlMs: -1 });
+    expect(bridge.readRequestState(token)).toBeNull();
+  });
+
+  it('buildInputRequiredSuspension packages resultType/inputRequests/requestState', () => {
+    const { bridge } = makeBridge();
+    const suspension = bridge.buildInputRequiredSuspension(
+      {
+        message: 'Solve the CAPTCHA',
+        requestedSchema: {
+          type: 'object',
+          properties: { solved: { type: 'boolean' } },
+          required: ['solved'],
+        },
+      },
+      { challengeType: 'widget' },
+      { kind: 'captcha_manual', instruction: 'resume later' },
+    );
+
+    expect(suspension.resultType).toBe('input_required');
+    expect(suspension.inputRequests).toHaveLength(1);
+    expect(suspension.inputRequests[0]?.type).toBe('form');
+    expect(suspension.instruction).toBe('resume later');
+
+    // The embedded state must decode back to the same form + context.
+    const decoded = bridge.resumeFromState<{ challengeType?: string }>(
+      suspension.requestState,
+      'captcha_manual',
+    );
+    expect(decoded?.formParams.message).toBe('Solve the CAPTCHA');
+    expect(decoded?.state.data.challengeType).toBe('widget');
+  });
+
+  it('resumeFromState refuses tokens of a different kind', () => {
+    const { bridge } = makeBridge();
+    const token = bridge.createRequestState(
+      { formParams: { message: 'x', requestedSchema: { type: 'object', properties: {} } } },
+      { kind: 'other_flow' },
+    );
+    expect(bridge.resumeFromState(token, 'captcha_manual')).toBeNull();
+  });
+
+  it('requestInputAndAwait resumes the executor on accept (elicitation-capable client)', async () => {
+    const { bridge } = makeBridge({
+      elicitationSupported: true,
+      elicitResult: { action: 'accept', content: { solved: true, token: 'T-1' } },
+    });
+
+    const response = await bridge.requestInputAndAwait(
+      { message: 'go', requestedSchema: { type: 'object', properties: {} } },
+      async (responses) => R.ok().set('token', responses.token).json(),
+      { stateKind: 'captcha_manual' },
+    );
+
+    const parsed = R.parse<Record<string, unknown>>(response);
+    expect(parsed.success).toBe(true);
+    expect(parsed.token).toBe('T-1');
+  });
+
+  it('requestInputAndAwait fails cleanly on decline/dismiss', async () => {
+    const { bridge } = makeBridge({
+      elicitationSupported: true,
+      elicitResult: { action: 'decline' },
+    });
+
+    const response = await bridge.requestInputAndAwait(
+      { message: 'go', requestedSchema: { type: 'object', properties: {} } },
+      async () => R.ok().json(),
+    );
+
+    const parsed = R.parse<Record<string, unknown>>(response);
+    expect(parsed.success).toBe(false);
+    expect(parsed.inputResult).toBe('decline');
+  });
+
+  it('requestInputAndAwait suspends with InputRequiredResult when the client cannot elicit', async () => {
+    const { bridge } = makeBridge({ elicitationSupported: false });
+
+    const response = await bridge.requestInputAndAwait(
+      { message: 'go', requestedSchema: { type: 'object', properties: {} } },
+      async () => R.ok().json(),
+      { stateKind: 'captcha_manual', instruction: 'resume with resumeToken' },
+    );
+
+    expect(bridge.isInputRequiredSuspension(response)).toBe(true);
+    const parsed = R.parse<Record<string, unknown>>(response);
+    expect(parsed.resultType).toBe('input_required');
+    expect(Array.isArray(parsed.inputRequests)).toBe(true);
+    expect(typeof parsed.requestState).toBe('string');
+    // The executor must NOT have run during suspension.
+    expect(parsed.success).toBe(true);
+  });
+
+  it('suspension → resume round-trip works end to end', async () => {
+    const { bridge } = makeBridge({ elicitationSupported: false });
+
+    const suspended = await bridge.requestInputAndAwait(
+      { message: 'solve it', requestedSchema: { type: 'object', properties: {} } },
+      async () => R.ok().json(),
+      { stateKind: 'captcha_manual' },
+    );
+    const parsed = R.parse<{ requestState: string }>(suspended);
+
+    const decoded = bridge.resumeFromState(parsed.requestState, 'captcha_manual');
+    expect(decoded).not.toBeNull();
+    expect(decoded!.formParams.message).toBe('solve it');
+  });
+});


### PR DESCRIPTION
Stack 4/6. Manual captcha mode suspends via ElicitationBridge (inline elicitation when supported, InputRequiredResult-style envelope + encrypted AES-256-GCM requestState otherwise); client resumes with resumeToken + resumeResponses. Also fixes widget manual mode being blocked by the siteKey guard. ~637 lines.

## Summary by Sourcery

Enable manual CAPTCHA solving to pause for user input and resume securely across tool calls.

New Features:
- Add manual CAPTCHA suspend/resume support through inline elicitation or encrypted input-required responses.
- Support resuming manual CAPTCHA flows with response tokens and completion status.

Bug Fixes:
- Allow manual widget CAPTCHA solving without requiring a site key.

Enhancements:
- Provide reusable encrypted, expiring request-state handling and input-required suspension utilities in the elicitation bridge.

Tests:
- Add coverage for request-state security, expiration, elicitation behavior, suspension, and CAPTCHA resume flows.