### PR TITLE
test(env-contract): file-level 180s timeout for corpus-scanning tests

### DIFF
--- a/tests/scripts/env-example.test.ts
+++ b/tests/scripts/env-example.test.ts
@@ -8,6 +8,11 @@ import {
   collectTypedEnvironmentReaders,
 } from './env-example-contract';
 
+// Every test in this file Babel-parses the whole src/ corpus; under coverage
+// instrumentation the scan roughly doubles and exceeds the 30s default on
+// slower runners.
+vi.setConfig({ testTimeout: 180_000 });
+
 interface EnvExampleEntry {
   key: string;
   rawValue: string;


### PR DESCRIPTION
Every test in tests/scripts/env-example.test.ts Babel-parses the whole src/ corpus; under coverage instrumentation the scan roughly doubles and exceeds the 30s default on slower runners (observed locally; CI passes but the local pre-push gate trips). Sets a file-level vi.setConfig testTimeout of 180s. 2-line change.

## Summary by Sourcery

Enhancements:
- Increase the timeout for corpus-scanning environment contract tests to accommodate slower coverage-instrumented runs.