### PR TITLE
fix(mcp2): restore legacy task protocol compatibility

### DIFF
--- a/src/server/tasks/TaskStoreAdapter.ts
+++ b/src/server/tasks/TaskStoreAdapter.ts
@@ -12,6 +12,7 @@
  *
  * @module TaskStoreAdapter
  */
+import { ProtocolError, ProtocolErrorCode } from '@modelcontextprotocol/server';
 import type { Server, Task } from '@modelcontextprotocol/server';
 import {
   CancelTaskResultSchema,
@@ -27,6 +28,18 @@ import { z } from 'zod';
 const TaskIdParamsSchema = z.object({ taskId: z.string() });
 const ListTasksParamsSchema = z.object({ cursor: z.string().optional() });
 import type { TaskManager, TaskRecord } from './TaskManager';
+
+const MAX_RESULT_WAIT_MS = 30_000;
+const RESULT_POLL_INTERVAL_MS = 100;
+const TERMINAL_STATUSES = new Set<TaskRecord['status']>(['completed', 'failed', 'cancelled']);
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function invalidTask(taskId: string): ProtocolError {
+  return new ProtocolError(ProtocolErrorCode.InvalidParams, `Unknown task: ${taskId}`);
+}
 
 /**
  * Adapts a {@link TaskManager} to the legacy (2025-11-25) task method surface.
@@ -60,17 +73,52 @@ export class TaskStoreAdapter {
     protocol.setRequestHandler(
       'tasks/result',
       { params: TaskIdParamsSchema, result: GetTaskPayloadResultSchema },
-      (params, ctx) => {
-        const payload = this.taskManager.getTaskPayload(params.taskId, ctx?.sessionId);
+      async (params, ctx) => {
+        const deadline = Date.now() + MAX_RESULT_WAIT_MS;
+        let payload = this.taskManager.getTaskPayload(params.taskId, ctx?.sessionId);
+        while (payload && !TERMINAL_STATUSES.has(payload.status) && Date.now() < deadline) {
+          await sleep(RESULT_POLL_INTERVAL_MS);
+          payload = this.taskManager.getTaskPayload(params.taskId, ctx?.sessionId);
+        }
         if (!payload) {
-          throw new Error(`Task not found: ${params.taskId}`);
+          throw invalidTask(params.taskId);
+        }
+        if (!TERMINAL_STATUSES.has(payload.status)) {
+          throw new ProtocolError(
+            ProtocolErrorCode.InternalError,
+            `Task result timed out while task remained ${payload.status}: ${params.taskId}`,
+          );
         }
         if (payload.status === 'failed') {
-          throw new Error(payload.error ?? 'Task failed');
+          throw new ProtocolError(ProtocolErrorCode.InternalError, payload.error ?? 'Task failed');
         }
+        if (payload.status === 'cancelled') {
+          throw new ProtocolError(
+            ProtocolErrorCode.InvalidParams,
+            `Task cancelled: ${params.taskId}`,
+          );
+        }
+        const relatedTaskMeta = {
+          ['io.modelcontextprotocol/related-task']: { taskId: params.taskId },
+        };
+        if (payload.result === undefined) return { _meta: relatedTaskMeta };
+        if (
+          typeof payload.result !== 'object' ||
+          payload.result === null ||
+          Array.isArray(payload.result)
+        ) {
+          return {
+            content: [{ type: 'text', text: String(payload.result) }],
+            _meta: relatedTaskMeta,
+          };
+        }
+        const result = payload.result as Record<string, unknown>;
         return {
-          status: payload.status,
-          ...(payload.result !== undefined ? { result: payload.result } : {}),
+          ...result,
+          _meta: {
+            ...(typeof result._meta === 'object' && result._meta !== null ? result._meta : {}),
+            ...relatedTaskMeta,
+          },
         };
       },
     );
@@ -88,9 +136,20 @@ export class TaskStoreAdapter {
       'tasks/cancel',
       { params: TaskIdParamsSchema, result: CancelTaskResultSchema },
       async (params, ctx) => {
-        await this.taskManager.cancelTask(params.taskId, ctx?.sessionId);
+        const task = this.taskManager.getTask(params.taskId, ctx?.sessionId);
+        if (!task || task.status !== 'working') {
+          throw invalidTask(params.taskId);
+        }
+        const cancelled = await this.taskManager.cancelTask(params.taskId, ctx?.sessionId);
+        if (!cancelled) {
+          throw invalidTask(params.taskId);
+        }
         // CancelTaskResult is flat — the task fields sit at the result top level.
-        return this.toSdkTask(this.taskManager.getTask(params.taskId, ctx?.sessionId)!);
+        const cancelledTask = this.taskManager.getTask(params.taskId, ctx?.sessionId);
+        if (!cancelledTask) {
+          throw invalidTask(params.taskId);
+        }
+        return this.toSdkTask(cancelledTask);
       },
     );
   }
@@ -108,7 +167,7 @@ export class TaskStoreAdapter {
   } {
     const payload = this.taskManager.getTaskPayload(taskId);
     if (!payload) {
-      throw new Error(`Task not found: ${taskId}`);
+      throw invalidTask(taskId);
     }
     return payload;
   }
@@ -116,7 +175,7 @@ export class TaskStoreAdapter {
   private getTaskOrThrow(taskId: string, callerSession?: string | null): Task {
     const record = this.taskManager.getTask(taskId, callerSession);
     if (!record) {
-      throw new Error(`Task not found: ${taskId}`);
+      throw invalidTask(taskId);
     }
     return this.toSdkTask(record);
   }

--- a/src/utils/environmentDoctor.ts
+++ b/src/utils/environmentDoctor.ts
@@ -166,7 +166,10 @@ export async function runEnvironmentDoctor(options?: {
   const corepackCommand = normalizeCorepackCheck(corepackCheck, pnpmCommand);
 
   const packages: DoctorCheck[] = [
-    checkPackage('@modelcontextprotocol/sdk'),
+    checkPackage('@modelcontextprotocol/core'),
+    checkPackage('@modelcontextprotocol/node'),
+    checkPackage('@modelcontextprotocol/server'),
+    checkPackage('@modelcontextprotocol/client'),
     checkPackage('rebrowser-puppeteer-core'),
     checkBetterSqlite3(),
     checkPackage('camoufox-js', 'Optional Firefox anti-detect driver'),

--- a/tests/server/tasks/TaskStoreAdapter.test.ts
+++ b/tests/server/tasks/TaskStoreAdapter.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { ProtocolErrorCode } from '@modelcontextprotocol/server';
 import { TaskManager } from '@server/tasks/TaskManager';
 import { TaskStoreAdapter } from '@server/tasks/TaskStoreAdapter';
 
@@ -46,7 +47,9 @@ describe('TaskStoreAdapter (legacy 2025-11-25 task methods over v2)', () => {
     expect(res.ttl).toBeTypeOf('number');
     expect(['working', 'completed']).toContain(res.status);
 
-    await expect(call('tasks/get', { taskId: 'ghost' })).rejects.toThrow('Task not found');
+    await expect(call('tasks/get', { taskId: 'ghost' })).rejects.toMatchObject({
+      code: ProtocolErrorCode.InvalidParams,
+    });
   });
 
   it('tasks/result returns the stored payload for completed tasks', async () => {
@@ -54,16 +57,30 @@ describe('TaskStoreAdapter (legacy 2025-11-25 task methods over v2)', () => {
     const adapter = new TaskStoreAdapter(tm);
     const task = await tm.createTask({
       name: 'demo',
-      executor: async () => ({ blockCount: 3 }),
+      executor: async () => ({ content: [{ type: 'text', text: 'done' }], blockCount: 3 }),
     });
     const { call } = installSpy(adapter);
 
-    const res = (await call('tasks/result', { taskId: task.taskId })) as {
-      status: string;
-      result?: unknown;
-    };
-    expect(res.status).toBe('completed');
-    expect(res.result).toEqual({ blockCount: 3 });
+    const res = (await call('tasks/result', { taskId: task.taskId })) as Record<string, unknown>;
+    expect(res).toMatchObject({ content: [{ type: 'text', text: 'done' }], blockCount: 3 });
+    expect(res._meta).toMatchObject({
+      ['io.modelcontextprotocol/related-task']: { taskId: task.taskId },
+    });
+  });
+
+  it('tasks/result waits for a working task to reach a terminal state', async () => {
+    let resolveExecutor!: (value: { content: never[] }) => void;
+    const executorDone = new Promise<{ content: never[] }>((resolve) => {
+      resolveExecutor = resolve;
+    });
+    const tm = new TaskManager();
+    const adapter = new TaskStoreAdapter(tm);
+    const task = await tm.createTask({ name: 'deferred', executor: async () => executorDone });
+    const { call } = installSpy(adapter);
+    const resultPromise = call('tasks/result', { taskId: task.taskId });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    resolveExecutor({ content: [] });
+    await expect(resultPromise).resolves.toMatchObject({ content: [] });
   });
 
   it('tasks/result throws for failed and unknown tasks', async () => {
@@ -78,7 +95,9 @@ describe('TaskStoreAdapter (legacy 2025-11-25 task methods over v2)', () => {
     const { call } = installSpy(adapter);
 
     await expect(call('tasks/result', { taskId: failing.taskId })).rejects.toThrow('bad');
-    await expect(call('tasks/result', { taskId: 'ghost' })).rejects.toThrow('Task not found');
+    await expect(call('tasks/result', { taskId: 'ghost' })).rejects.toMatchObject({
+      code: ProtocolErrorCode.InvalidParams,
+    });
   });
 
   it('tasks/cancel cancels a working task and returns its post-cancel state', async () => {
@@ -98,6 +117,21 @@ describe('TaskStoreAdapter (legacy 2025-11-25 task methods over v2)', () => {
     };
     expect(res.status).toBe('cancelled');
     expect(tm.getTask(task.taskId)?.status).toBe('cancelled');
+  });
+
+  it('tasks/cancel rejects unknown and terminal tasks with InvalidParams', async () => {
+    const tm = new TaskManager();
+    const adapter = new TaskStoreAdapter(tm);
+    const completed = await tm.createTask({ name: 'done', executor: async () => 1 });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const { call } = installSpy(adapter);
+
+    await expect(call('tasks/cancel', { taskId: 'ghost' })).rejects.toMatchObject({
+      code: ProtocolErrorCode.InvalidParams,
+    });
+    await expect(call('tasks/cancel', { taskId: completed.taskId })).rejects.toMatchObject({
+      code: ProtocolErrorCode.InvalidParams,
+    });
   });
 
   it('tasks/list maps every record to the wire shape', async () => {

--- a/tests/utils/environmentDoctor.edge-cases.test.ts
+++ b/tests/utils/environmentDoctor.edge-cases.test.ts
@@ -279,13 +279,13 @@ describe('environmentDoctor edge cases (require-mocked)', () => {
     expect(pkg!.detail).toBe('installed');
   });
 
-  // ── checkPackage missingHint ?? 'Not installed' branch (L166) ──
+  // ── checkPackage missingHint ?? 'Not installed' branch ──
 
   it('uses default "Not installed" when missing package has no missingHint', async () => {
-    // @modelcontextprotocol/sdk has no missingHint argument
-    blockedPackages.add('@modelcontextprotocol/sdk');
+    // @modelcontextprotocol/core has no missingHint argument
+    blockedPackages.add('@modelcontextprotocol/core');
     const report = await runEnvironmentDoctor({ includeBridgeHealth: false });
-    const sdk = report.packages.find((p) => p.name === '@modelcontextprotocol/sdk');
+    const sdk = report.packages.find((p) => p.name === '@modelcontextprotocol/core');
     expect(sdk).toBeDefined();
     expect(sdk!.status).toBe('missing');
     expect(sdk!.detail).toBe('Not installed');

--- a/tests/utils/environmentDoctor.test.ts
+++ b/tests/utils/environmentDoctor.test.ts
@@ -145,9 +145,16 @@ describe('runEnvironmentDoctor', () => {
 
   it('reports installed packages', async () => {
     const report = await runEnvironmentDoctor({ includeBridgeHealth: false });
-    const mcpSdk = report.packages.find((p) => p.name === '@modelcontextprotocol/sdk');
-    expect(mcpSdk).toBeDefined();
-    expect(['ok', 'missing']).toContain(mcpSdk!.status);
+    for (const packageName of [
+      '@modelcontextprotocol/core',
+      '@modelcontextprotocol/node',
+      '@modelcontextprotocol/server',
+      '@modelcontextprotocol/client',
+    ]) {
+      const packageCheck = report.packages.find((p) => p.name === packageName);
+      expect(packageCheck).toBeDefined();
+      expect(['ok', 'missing']).toContain(packageCheck!.status);
+    }
   });
 
   it('includes better-sqlite3 health in package checks', async () => {


### PR DESCRIPTION
## Summary

- Restore legacy `tasks/result` waiting and top-level MCP Result wire shape.
- Attach `io.modelcontextprotocol/related-task` metadata to task results.
- Return protocol-level InvalidParams for unknown, cancelled, or terminal task operations.
- Update Environment Doctor checks to MCP SDK v2 split packages.
- Add regression coverage for waiting, metadata, error codes, cancellation, and package checks.

## Verification

- `pnpm check`
- `pnpm exec tsx src/cli/doctor.ts`

Full check result: 1286 test files passed, 19,483 tests passed (7 files and 76 tests skipped). 