### PR TITLE
feat(tasks): async task modes for long-running tools

### DIFF
--- a/src/modules/binary-instrument/FridaSession.ts
+++ b/src/modules/binary-instrument/FridaSession.ts
@@ -48,6 +48,12 @@ export interface MemoryScanOptions {
   address?: string;
   size?: number;
   max?: number;
+  /**
+   * Per-invocation CLI timeout in milliseconds. Defaults to FRIDA_TIMEOUT_MS
+   * (15s). Task-mode callers pass a larger value so broad memory scans
+   * survive past the interactive timeout (MCP 2.0 Tasks retrofit).
+   */
+  timeoutMs?: number;
 }
 
 export type FridaSessionMode = 'attach' | 'spawn';
@@ -144,9 +150,12 @@ export class FridaSession {
     this.activeSessionId = undefined;
   }
 
-  async executeScript(script: string): Promise<FridaScriptResult> {
+  async executeScript(
+    script: string,
+    options: { timeoutMs?: number } = {},
+  ): Promise<FridaScriptResult> {
     const session = this.requireActiveSession();
-    const result = await this.runFridaCommandForSession(session, script);
+    const result = await this.runFridaCommandForSession(session, script, options.timeoutMs);
 
     if (result.error) {
       session.status = 'error';
@@ -313,6 +322,7 @@ export class FridaSession {
         '}',
         'console.log(JSON.stringify(results));',
       ].join('\n'),
+      options.timeoutMs,
     );
     const parsed = this.parseMemoryMatchList(result.output);
 
@@ -451,18 +461,20 @@ export class FridaSession {
   private async runFridaCommandForSession(
     session: FridaSessionRecord,
     script: string,
+    timeoutMs?: number,
   ): Promise<FridaScriptResult> {
     const targetArgs =
       session.mode === 'spawn' && session.resumed !== true
         ? this.buildSpawnTargetArgs(session.target)
         : this.buildTargetArgs(session.target);
-    return this.runFridaCommandWithArgs(session.target, targetArgs, script);
+    return this.runFridaCommandWithArgs(session.target, targetArgs, script, timeoutMs);
   }
 
   private async runFridaCommandWithArgs(
     target: string,
     targetArgs: string[],
     script: string,
+    timeoutMs?: number,
   ): Promise<FridaScriptResult> {
     const availability = await this.getAvailability();
     if (!availability.available) {
@@ -476,7 +488,7 @@ export class FridaSession {
     const args = [...targetArgs, '--runtime=v8', '-q', '-e', script];
 
     try {
-      const result = await this.execFileUtf8(command, args, FRIDA_TIMEOUT_MS);
+      const result = await this.execFileUtf8(command, args, timeoutMs ?? FRIDA_TIMEOUT_MS);
       const output = result.stdout.trim();
       const error = result.stderr.trim();
       return error ? { output, error } : { output };

--- a/src/modules/binary-instrument/FridaSession.ts
+++ b/src/modules/binary-instrument/FridaSession.ts
@@ -54,6 +54,8 @@ export interface MemoryScanOptions {
    * survive past the interactive timeout (MCP 2.0 Tasks retrofit).
    */
   timeoutMs?: number;
+  /** Aborted by task cancellation — kills the frida CLI child mid-scan. */
+  signal?: AbortSignal;
 }
 
 export type FridaSessionMode = 'attach' | 'spawn';
@@ -152,10 +154,15 @@ export class FridaSession {
 
   async executeScript(
     script: string,
-    options: { timeoutMs?: number } = {},
+    options: { timeoutMs?: number; signal?: AbortSignal } = {},
   ): Promise<FridaScriptResult> {
     const session = this.requireActiveSession();
-    const result = await this.runFridaCommandForSession(session, script, options.timeoutMs);
+    const result = await this.runFridaCommandForSession(
+      session,
+      script,
+      options.timeoutMs,
+      options.signal,
+    );
 
     if (result.error) {
       session.status = 'error';
@@ -323,6 +330,7 @@ export class FridaSession {
         'console.log(JSON.stringify(results));',
       ].join('\n'),
       options.timeoutMs,
+      options.signal,
     );
     const parsed = this.parseMemoryMatchList(result.output);
 
@@ -462,12 +470,13 @@ export class FridaSession {
     session: FridaSessionRecord,
     script: string,
     timeoutMs?: number,
+    signal?: AbortSignal,
   ): Promise<FridaScriptResult> {
     const targetArgs =
       session.mode === 'spawn' && session.resumed !== true
         ? this.buildSpawnTargetArgs(session.target)
         : this.buildTargetArgs(session.target);
-    return this.runFridaCommandWithArgs(session.target, targetArgs, script, timeoutMs);
+    return this.runFridaCommandWithArgs(session.target, targetArgs, script, timeoutMs, signal);
   }
 
   private async runFridaCommandWithArgs(
@@ -475,6 +484,7 @@ export class FridaSession {
     targetArgs: string[],
     script: string,
     timeoutMs?: number,
+    signal?: AbortSignal,
   ): Promise<FridaScriptResult> {
     const availability = await this.getAvailability();
     if (!availability.available) {
@@ -488,7 +498,7 @@ export class FridaSession {
     const args = [...targetArgs, '--runtime=v8', '-q', '-e', script];
 
     try {
-      const result = await this.execFileUtf8(command, args, timeoutMs ?? FRIDA_TIMEOUT_MS);
+      const result = await this.execFileUtf8(command, args, timeoutMs ?? FRIDA_TIMEOUT_MS, signal);
       const output = result.stdout.trim();
       const error = result.stderr.trim();
       return error ? { output, error } : { output };
@@ -687,9 +697,14 @@ export class FridaSession {
     return typeof value === 'object' && value !== null;
   }
 
-  private execFileUtf8(file: string, args: string[], timeoutMs: number): Promise<CommandResult> {
+  private execFileUtf8(
+    file: string,
+    args: string[],
+    timeoutMs: number,
+    signal?: AbortSignal,
+  ): Promise<CommandResult> {
     return new Promise((resolve, reject) => {
-      execFile(
+      const child = execFile(
         file,
         args,
         {
@@ -699,6 +714,7 @@ export class FridaSession {
           encoding: 'utf8',
         },
         (error, stdout, stderr) => {
+          signal?.removeEventListener('abort', onAbort);
           if (error) {
             reject(error);
             return;
@@ -710,6 +726,13 @@ export class FridaSession {
           });
         },
       );
+
+      // Task cancellation must actually stop the CLI child — otherwise a
+      // cancelled frida scan keeps burning CPU on the target for minutes.
+      function onAbort() {
+        child.kill();
+      }
+      signal?.addEventListener('abort', onAbort, { once: true });
     });
   }
 }

--- a/src/server/domains/binary-instrument/definitions.ts
+++ b/src/server/domains/binary-instrument/definitions.ts
@@ -70,9 +70,22 @@ export const binaryInstrumentTools: Tool[] = [
   ),
   tool('frida_run_script', (t) =>
     t
-      .desc('Execute a Frida JavaScript snippet inside an attached Frida session.')
+      .desc(
+        'Execute a Frida JavaScript snippet inside an attached Frida session. Pass async:true to run in a ' +
+          'background task (MCP 2.0 Tasks) and poll with tasks_get/tasks_result — useful for long-running or ' +
+          'persistent instrumentation scripts that would otherwise hit the CLI timeout.',
+      )
       .string('sessionId', 'Session id returned by frida_attach')
       .string('script', 'Frida JavaScript to execute')
+      .boolean(
+        'async',
+        'Run as a background task and return a taskId immediately (poll with tasks_get/tasks_result)',
+        { default: false },
+      )
+      .number(
+        'timeoutMs',
+        'CLI timeout in milliseconds for async mode (default 300000, capped at 600000)',
+      )
       .required('sessionId', 'script'),
   ),
   tool('frida_resume', (t) =>
@@ -424,7 +437,7 @@ export const binaryInstrumentTools: Tool[] = [
   tool('frida_memory_scan', (t) =>
     t
       .desc(
-        'Scan process memory for a byte pattern via Frida Memory.scanSync. Searches a named module, an explicit address range, or all readable ranges by default.',
+        'Scan process memory for a byte pattern via Frida Memory.scanSync. Searches a named module, an explicit address range, or all readable ranges by default. Pass async:true to scan in a background task (MCP 2.0 Tasks) and poll with tasks_get/tasks_result — broad scans survive past the default 15s CLI timeout.',
       )
       .string('sessionId', 'Session id returned by frida_attach')
       .string('pattern', 'Frida byte pattern, e.g. "DE AD BE EF" or "cafebabe"')
@@ -435,6 +448,15 @@ export const binaryInstrumentTools: Tool[] = [
       )
       .number('size', 'Optional number of bytes to scan when address is given.')
       .number('max', 'Maximum matches to return (default 1000, capped at 10000).')
+      .boolean(
+        'async',
+        'Run as a background task and return a taskId immediately (poll with tasks_get/tasks_result)',
+        { default: false },
+      )
+      .number(
+        'timeoutMs',
+        'CLI timeout in milliseconds for async mode (default 300000, capped at 600000)',
+      )
       .required('sessionId', 'pattern')
       .query(),
   ),

--- a/src/server/domains/binary-instrument/handlers/frida-handlers.ts
+++ b/src/server/domains/binary-instrument/handlers/frida-handlers.ts
@@ -235,7 +235,10 @@ export class FridaHandlers {
           name: 'frida_run_script',
           executor: async (ctx) => {
             ctx.updateProgress(5, 100, 'Executing Frida script...');
-            const execution = await frida.executeScript(script, { timeoutMs: taskTimeoutMs });
+            const execution = await frida.executeScript(script, {
+              timeoutMs: taskTimeoutMs,
+              signal: ctx.signal,
+            });
             ctx.updateProgress(100, 100, 'Script execution finished');
             return execution;
           },
@@ -643,6 +646,7 @@ export class FridaHandlers {
               size: rawSize,
               max: rawMax,
               timeoutMs: taskTimeoutMs,
+              signal: ctx.signal,
             });
             ctx.updateProgress(100, 100, `Scan finished: ${matches.length} match(es)`);
             return { sessionId, pattern, matches, count: matches.length };

--- a/src/server/domains/binary-instrument/handlers/frida-handlers.ts
+++ b/src/server/domains/binary-instrument/handlers/frida-handlers.ts
@@ -30,6 +30,21 @@ interface InterceptorScriptOptions {
   onLeaveBody?: string;
 }
 
+/** Ceiling for task-mode CLI timeouts; stays inside TaskManager's 10-minute default TTL. */
+const FRIDA_TASK_MAX_TIMEOUT_MS = 10 * 60_000;
+const FRIDA_TASK_DEFAULT_TIMEOUT_MS = 5 * 60_000;
+
+/**
+ * Resolve the task-mode CLI timeout from tool args. Returns undefined for the
+ * synchronous path so FridaSession keeps its default FRIDA_TIMEOUT_MS.
+ */
+function readTaskTimeoutMs(args: Record<string, unknown>): number | undefined {
+  if (readOptionalBoolean(args, 'async') !== true) return undefined;
+  const requested = typeof args.timeoutMs === 'number' ? args.timeoutMs : undefined;
+  if (requested === undefined) return FRIDA_TASK_DEFAULT_TIMEOUT_MS;
+  return Math.max(1000, Math.min(requested, FRIDA_TASK_MAX_TIMEOUT_MS));
+}
+
 export class FridaHandlers {
   private state: BinaryInstrumentState;
 
@@ -208,6 +223,34 @@ export class FridaHandlers {
         reason: `Unknown Frida session: ${sessionId}`,
         execution: { output: '', error: 'Unknown session' },
       });
+    }
+
+    // Task mode: run the script in the background and return a taskId immediately
+    // (MCP 2.0 Tasks retrofit — long/hanging scripts no longer hit the CLI timeout).
+    const taskTimeoutMs = readTaskTimeoutMs(args);
+    if (taskTimeoutMs !== undefined) {
+      const taskManager = this.state.context?.taskManager;
+      if (taskManager) {
+        const task = await taskManager.createTask({
+          name: 'frida_run_script',
+          executor: async (ctx) => {
+            ctx.updateProgress(5, 100, 'Executing Frida script...');
+            const execution = await frida.executeScript(script, { timeoutMs: taskTimeoutMs });
+            ctx.updateProgress(100, 100, 'Script execution finished');
+            return execution;
+          },
+        });
+        return jsonResponse({
+          success: true,
+          available: true,
+          async: true,
+          sessionId,
+          taskId: task.taskId,
+          status: task.status,
+          pollWith: ['tasks_get', 'tasks_result'],
+          cancelWith: 'tasks_cancel',
+        });
+      }
     }
 
     const execution = await frida.executeScript(script);
@@ -581,6 +624,42 @@ export class FridaHandlers {
         reason: `Unknown Frida session: ${sessionId}`,
         matches: [],
       });
+    }
+
+    // Task mode: scan in the background and return a taskId immediately
+    // (MCP 2.0 Tasks retrofit — broad scans survive past the CLI timeout).
+    const taskTimeoutMs = readTaskTimeoutMs(args);
+    if (taskTimeoutMs !== undefined) {
+      const taskManager = this.state.context?.taskManager;
+      if (taskManager) {
+        const scanLabel = moduleName ?? 'all readable ranges';
+        const task = await taskManager.createTask({
+          name: 'frida_memory_scan',
+          executor: async (ctx) => {
+            ctx.updateProgress(5, 100, `Scanning ${scanLabel} for ${pattern}`);
+            const matches = await frida.memoryScan(pattern, {
+              moduleName: moduleName ?? undefined,
+              address: address ?? undefined,
+              size: rawSize,
+              max: rawMax,
+              timeoutMs: taskTimeoutMs,
+            });
+            ctx.updateProgress(100, 100, `Scan finished: ${matches.length} match(es)`);
+            return { sessionId, pattern, matches, count: matches.length };
+          },
+        });
+        return jsonResponse({
+          success: true,
+          available: true,
+          async: true,
+          sessionId,
+          pattern,
+          taskId: task.taskId,
+          status: task.status,
+          pollWith: ['tasks_get', 'tasks_result'],
+          cancelWith: 'tasks_cancel',
+        });
+      }
     }
 
     const matches = await frida.memoryScan(pattern, {

--- a/src/server/domains/protocol-analysis/definitions.ts
+++ b/src/server/domains/protocol-analysis/definitions.ts
@@ -309,7 +309,8 @@ export const protocolAnalysisTools: Tool[] = [
       .desc(
         'Read a PCAPNG (pcap-ng) capture file and return structured Section/Interface/Packet blocks. Supports ' +
           'Section Header, Interface Description, Enhanced/Simple Packet, Name Resolution, and Interface Statistics ' +
-          'blocks; unknown block types are surfaced as warnings.',
+          'blocks; unknown block types are surfaced as warnings. For multi-MB captures pass async:true to parse in a ' +
+          'background task (MCP 2.0 Tasks) and poll with tasks_get/tasks_result instead of blocking this call.',
       )
       .string('path', 'Path to the PCAPNG file to parse')
       .number('maxPackets', 'Maximum number of packet records to decode')
@@ -320,6 +321,11 @@ export const protocolAnalysisTools: Tool[] = [
       .number(
         'interfaceFilter',
         'When set, only Enhanced Packet Blocks matching this interface ID are returned (Simple Packet Blocks pass through)',
+      )
+      .boolean(
+        'async',
+        'Run the parse as a background task and return a taskId immediately (poll with tasks_get/tasks_result)',
+        { default: false },
       )
       .required('path')
       .query(),

--- a/src/server/domains/protocol-analysis/handlers/base.ts
+++ b/src/server/domains/protocol-analysis/handlers/base.ts
@@ -20,6 +20,8 @@ export class ProtocolAnalysisBaseHandlers {
   protected engine?: ProtocolPatternEngine;
   protected inferrer?: StateMachineInferrer;
   protected eventBus?: EventBus<ServerEventMap>;
+  /** MCP 2.0 Tasks scheduler — set via manifest ensure() for task-aware tools (pcapng_read). */
+  protected taskManager?: import('@server/tasks/TaskManager').TaskManager;
   /** Shared large-response sink; lazy-init via getInstance() so tests can reset it. */
   protected readonly detailedDataManager: DetailedDataManager = DetailedDataManager.getInstance();
 
@@ -27,10 +29,12 @@ export class ProtocolAnalysisBaseHandlers {
     engine?: ProtocolPatternEngine,
     inferrer?: StateMachineInferrer,
     eventBus?: EventBus<ServerEventMap>,
+    taskManager?: import('@server/tasks/TaskManager').TaskManager,
   ) {
     this.engine = engine;
     this.inferrer = inferrer;
     this.eventBus = eventBus;
+    this.taskManager = taskManager;
   }
 
   protected emitEvent<K extends ProtocolAtomicEvent>(

--- a/src/server/domains/protocol-analysis/handlers/pcapng-handlers.ts
+++ b/src/server/domains/protocol-analysis/handlers/pcapng-handlers.ts
@@ -20,21 +20,78 @@ import { ProtocolAnalysisFingerprintHandlers } from './fingerprint-handlers';
 
 const HEX_RE = /^[0-9a-f]*$/iu;
 
+export interface PcapngReadPayload {
+  path: string;
+  endianness: string | null;
+  blockCount: number;
+  sections: PcapngReadResult['sections'];
+  interfaces: PcapngReadResult['interfaces'];
+  packets: PcapngPacketSummary[];
+  nameResolutionRecords: PcapngReadResult['nameResolutionRecords'];
+  interfaceStatistics: PcapngReadResult['interfaceStatistics'];
+  unknownBlocks: PcapngReadResult['unknownBlocks'];
+  warnings: string[];
+  success?: boolean;
+  error?: string;
+}
+
+/** Extra fields carried by the MCP 2.0 Tasks (async) branch of handlePcapngRead. */
+export interface PcapngReadTaskFields {
+  taskId?: string;
+  taskStatus?: string;
+  async?: boolean;
+}
+
 export class ProtocolAnalysisPcapngHandlers extends ProtocolAnalysisFingerprintHandlers {
-  async handlePcapngRead(args: ToolArgs): Promise<{
-    path: string;
-    endianness: string | null;
-    blockCount: number;
-    sections: PcapngReadResult['sections'];
-    interfaces: PcapngReadResult['interfaces'];
-    packets: PcapngPacketSummary[];
-    nameResolutionRecords: PcapngReadResult['nameResolutionRecords'];
-    interfaceStatistics: PcapngReadResult['interfaceStatistics'];
-    unknownBlocks: PcapngReadResult['unknownBlocks'];
-    warnings: string[];
-    success?: boolean;
-    error?: string;
-  }> {
+  /**
+   * Core pcapng parse — shared by the synchronous path and the MCP 2.0 Tasks
+   * background executor. Reads the file, parses blocks and offloads oversized
+   * packet payloads to the DetailedDataManager sink.
+   */
+  private async readPcapngCore(
+    path: string,
+    options: {
+      maxPackets?: number;
+      maxBytesPerPacket?: number;
+      interfaceFilter?: number;
+      offloadPacket?: (hex: string, packetIndex: number) => Promise<string>;
+    },
+  ): Promise<PcapngReadPayload> {
+    const buffer = await readFile(path);
+    if (buffer.length < 12) {
+      throw new Error('PCAPNG file is too small to contain a Section Header Block');
+    }
+    // Offload any packet payload whose hex exceeds 64 KiB to the shared
+    // DetailedDataManager sink — the summary then carries `dataRef` (a
+    // retrievable detailId) instead of inline `dataHex`, keeping multi-MB
+    // captures out of the LLM context window (matches the project's
+    // response-offload pipeline, issue #62).
+    const offloadPacket = (hex: string, packetIndex: number): Promise<string> => {
+      const detailId = this.detailedDataManager.store({ packetIndex, hex });
+      return detailId;
+    };
+    const result = await parsePcapng(buffer, { ...options, offloadPacket });
+    this.emitEvent('protocol:pcapng_read', {
+      path,
+      blockCount: result.blockCount,
+      packetCount: result.packets.length,
+    });
+    return {
+      path,
+      endianness: result.endianness,
+      blockCount: result.blockCount,
+      sections: result.sections,
+      interfaces: result.interfaces,
+      packets: result.packets,
+      nameResolutionRecords: result.nameResolutionRecords,
+      interfaceStatistics: result.interfaceStatistics,
+      unknownBlocks: result.unknownBlocks,
+      warnings: result.warnings,
+      success: true,
+    };
+  }
+
+  async handlePcapngRead(args: ToolArgs): Promise<PcapngReadPayload & PcapngReadTaskFields> {
     try {
       const path = this.parseRequiredPath(args);
       const maxPackets =
@@ -50,43 +107,45 @@ export class ProtocolAnalysisPcapngHandlers extends ProtocolAnalysisFingerprintH
           ? undefined
           : parseNonNegativeInteger(args.interfaceFilter, 'interfaceFilter');
 
-      const buffer = await readFile(path);
-      if (buffer.length < 12) {
-        throw new Error('PCAPNG file is too small to contain a Section Header Block');
+      // Task mode: parse in the background and return a taskId immediately
+      // (MCP 2.0 Tasks retrofit — multi-MB captures no longer block the caller).
+      if (args.async === true && this.taskManager) {
+        const task = await this.taskManager.createTask({
+          name: 'pcapng_read',
+          executor: async (ctx) => {
+            ctx.updateProgress(5, 100, `Reading ${path}...`);
+            const result = await this.readPcapngCore(path, {
+              maxPackets,
+              maxBytesPerPacket,
+              interfaceFilter,
+            });
+            ctx.updateProgress(100, 100, `Parsed ${result.blockCount} block(s)`);
+            return result;
+          },
+        });
+        return {
+          path,
+          endianness: null,
+          blockCount: 0,
+          sections: [],
+          interfaces: [],
+          packets: [],
+          nameResolutionRecords: [],
+          interfaceStatistics: [],
+          unknownBlocks: [],
+          warnings: [],
+          success: true,
+          taskId: task.taskId,
+          taskStatus: task.status,
+          async: true,
+        };
       }
-      // Offload any packet payload whose hex exceeds 64 KiB to the shared
-      // DetailedDataManager sink — the summary then carries `dataRef` (a
-      // retrievable detailId) instead of inline `dataHex`, keeping multi-MB
-      // captures out of the LLM context window (matches the project's
-      // response-offload pipeline, issue #62).
-      const offloadPacket = (hex: string, packetIndex: number): Promise<string> => {
-        const detailId = this.detailedDataManager.store({ packetIndex, hex });
-        return detailId;
-      };
-      const result = await parsePcapng(buffer, {
+
+      return await this.readPcapngCore(path, {
         maxPackets,
         maxBytesPerPacket,
         interfaceFilter,
-        offloadPacket,
       });
-      this.emitEvent('protocol:pcapng_read', {
-        path,
-        blockCount: result.blockCount,
-        packetCount: result.packets.length,
-      });
-      return {
-        path,
-        endianness: result.endianness,
-        blockCount: result.blockCount,
-        sections: result.sections,
-        interfaces: result.interfaces,
-        packets: result.packets,
-        nameResolutionRecords: result.nameResolutionRecords,
-        interfaceStatistics: result.interfaceStatistics,
-        unknownBlocks: result.unknownBlocks,
-        warnings: result.warnings,
-        success: true,
-      };
     } catch (error) {
       return {
         path: typeof args.path === 'string' ? args.path : '',

--- a/src/server/domains/protocol-analysis/handlers/pcapng-handlers.ts
+++ b/src/server/domains/protocol-analysis/handlers/pcapng-handlers.ts
@@ -55,9 +55,14 @@ export class ProtocolAnalysisPcapngHandlers extends ProtocolAnalysisFingerprintH
       maxBytesPerPacket?: number;
       interfaceFilter?: number;
       offloadPacket?: (hex: string, packetIndex: number) => Promise<string>;
+      signal?: AbortSignal;
     },
   ): Promise<PcapngReadPayload> {
     const buffer = await readFile(path);
+    // Cooperative abort between the I/O and parse stages (task cancellation).
+    if (options.signal?.aborted) {
+      throw new Error('pcapng read aborted');
+    }
     if (buffer.length < 12) {
       throw new Error('PCAPNG file is too small to contain a Section Header Block');
     }
@@ -118,6 +123,7 @@ export class ProtocolAnalysisPcapngHandlers extends ProtocolAnalysisFingerprintH
               maxPackets,
               maxBytesPerPacket,
               interfaceFilter,
+              signal: ctx.signal,
             });
             ctx.updateProgress(100, 100, `Parsed ${result.blockCount} block(s)`);
             return result;

--- a/src/server/domains/protocol-analysis/manifest.ts
+++ b/src/server/domains/protocol-analysis/manifest.ts
@@ -42,7 +42,12 @@ async function ensure(ctx: MCPServerContext): Promise<H> {
     return existing;
   }
 
-  const handlers = new ProtocolAnalysisHandlers(undefined, undefined, ctx.eventBus);
+  const handlers = new ProtocolAnalysisHandlers(
+    undefined,
+    undefined,
+    ctx.eventBus,
+    ctx.taskManager,
+  );
   ctx.setDomainInstance(DEP_KEY, handlers);
   return handlers;
 }

--- a/src/server/tasks/TaskManager.ts
+++ b/src/server/tasks/TaskManager.ts
@@ -55,11 +55,18 @@ export interface CreateTaskOptions<TResult = unknown> {
 export interface TaskExecutionContext {
   taskId: string;
   isCancelled: () => boolean;
+  /**
+   * Aborted by cancelTask()/shutdown(). Long-running executors should pass
+   * this into cancellable child operations (e.g. frida CLI processes) and/or
+   * poll it between stages instead of only relying on isCancelled().
+   */
+  signal: AbortSignal;
   updateProgress: (progress: number, total?: number, message?: string) => void;
 }
 
 export class TaskManager {
   private readonly tasks = new Map<string, TaskRecord>();
+  private readonly abortControllers = new Map<string, AbortController>();
   private readonly defaultTtlMs: number;
   private readonly maxTasks: number;
   /**
@@ -109,9 +116,13 @@ export class TaskManager {
 
     this.tasks.set(taskId, task as TaskRecord);
 
+    const abortController = new AbortController();
+    this.abortControllers.set(taskId, abortController);
+
     const executionContext: TaskExecutionContext = {
       taskId,
       isCancelled: () => task.status === 'cancelled',
+      signal: abortController.signal,
       updateProgress: (progress: number, total = 100, message?: string) => {
         if (task.status === 'working') {
           task.progress = progress;
@@ -160,6 +171,7 @@ export class TaskManager {
   async shutdown(): Promise<void> {
     const working = Array.from(this.tasks.values()).filter((t) => t.status === 'working');
     await Promise.allSettled(working.map((t) => this.cancelTask(t.taskId)));
+    this.abortControllers.clear();
     this.tasks.clear();
   }
 
@@ -220,6 +232,7 @@ export class TaskManager {
 
     task.status = 'cancelled';
     task.lastUpdatedAt = new Date().toISOString();
+    this.abortControllers.get(taskId)?.abort();
 
     if (task.cancelHandler) {
       try {
@@ -265,6 +278,7 @@ export class TaskManager {
       const updatedAt = new Date(task.lastUpdatedAt).getTime();
       if (now - updatedAt > task.ttl) {
         this.tasks.delete(id);
+        this.abortControllers.delete(id);
       }
     }
 
@@ -280,6 +294,7 @@ export class TaskManager {
         const entry = sorted[i];
         if (entry) {
           this.tasks.delete(entry[0]);
+          this.abortControllers.delete(entry[0]);
         }
       }
     }

--- a/tests/server/domains/binary-instrument/frida-task.test.ts
+++ b/tests/server/domains/binary-instrument/frida-task.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it, vi } from 'vitest';
+import { R } from '@server/domains/shared/ResponseBuilder';
+import { FridaHandlers } from '@server/domains/binary-instrument/handlers/frida-handlers';
+import type { BinaryInstrumentState } from '@server/domains/binary-instrument/handlers/shared';
+import type { FridaSession } from '@modules/binary-instrument';
+import { TaskManager } from '@server/tasks/TaskManager';
+import type { MCPServerContext } from '@server/MCPServer.context';
+
+function parse(res: unknown): Record<string, unknown> {
+  return R.parse<Record<string, unknown>>(res as Parameters<typeof R.parse>[0]);
+}
+
+function makeFakeSession(overrides: Record<string, unknown> = {}): FridaSession {
+  const base = {
+    getAvailability: vi.fn(async () => ({ available: true, path: 'frida' })),
+    useSession: vi.fn(() => true),
+    hasSession: vi.fn(() => true),
+    listSessions: vi.fn(() => []),
+    getSessionDiagnostics: vi.fn(() => undefined),
+    memoryScan: vi.fn(async () => [{ address: '0x00007ff000000000', size: 4 }]),
+    executeScript: vi.fn(async () => ({ output: 'ok' })),
+    detach: vi.fn(async () => undefined),
+    ...overrides,
+  };
+  return base as unknown as FridaSession;
+}
+
+function makeState(
+  taskManager: TaskManager | undefined,
+  session: FridaSession,
+): BinaryInstrumentState {
+  return {
+    fridaSession: session,
+    context: taskManager ? ({ taskManager } as unknown as MCPServerContext) : undefined,
+  } as BinaryInstrumentState;
+}
+
+describe('FridaHandlers — task mode (MCP 2.0 Tasks retrofit)', () => {
+  it('frida_memory_scan with async:true creates a task and threads a long timeoutMs', async () => {
+    const tm = new TaskManager();
+    const memoryScan = vi.fn(async () => [{ address: '0x42', size: 2 }]);
+    const session = makeFakeSession({ memoryScan });
+    const handlers = new FridaHandlers(makeState(tm, session));
+
+    const res = parse(
+      await handlers.handleFridaMemoryScan({
+        sessionId: 's1',
+        pattern: 'de ad be ef',
+        async: true,
+      } as Record<string, unknown>),
+    );
+
+    expect(res.success).toBe(true);
+    expect(res.async).toBe(true);
+    expect(typeof res.taskId).toBe('string');
+    expect(res.pollWith).toEqual(['tasks_get', 'tasks_result']);
+
+    // Executor ran against the fake session with the default task timeout (5 min).
+    expect(memoryScan).toHaveBeenCalledWith(
+      'de ad be ef',
+      expect.objectContaining({ timeoutMs: 5 * 60_000 }),
+    );
+
+    const payload = tm.getTaskPayload<{ matches: unknown[]; count: number }>(res.taskId as string);
+    expect(payload?.status).toBe('completed');
+    expect(payload?.result?.count).toBe(1);
+  });
+
+  it('frida_memory_scan respects an explicit async timeoutMs (bounded to the ceiling)', async () => {
+    const tm = new TaskManager();
+    const memoryScan = vi.fn(async () => []);
+    const session = makeFakeSession({ memoryScan });
+    const handlers = new FridaHandlers(makeState(tm, session));
+
+    await handlers.handleFridaMemoryScan({
+      sessionId: 's1',
+      pattern: 'aa',
+      async: true,
+      timeoutMs: 999_999_999,
+    } as Record<string, unknown>);
+
+    expect(memoryScan).toHaveBeenCalledWith(
+      'aa',
+      expect.objectContaining({ timeoutMs: 10 * 60_000 }),
+    );
+  });
+
+  it('frida_memory_scan without async keeps the synchronous behavior (no task)', async () => {
+    const tm = new TaskManager();
+    const memoryScan = vi.fn(async () => [{ address: '0x1', size: 1 }]);
+    const session = makeFakeSession({ memoryScan });
+    const handlers = new FridaHandlers(makeState(tm, session));
+
+    const res = parse(
+      await handlers.handleFridaMemoryScan({ sessionId: 's1', pattern: 'aa' } as Record<
+        string,
+        unknown
+      >),
+    );
+
+    expect(res.success).toBe(true);
+    expect(res.taskId).toBeUndefined();
+    expect(res.count).toBe(1);
+    expect(tm.listTasks()).toHaveLength(0);
+    expect(memoryScan).toHaveBeenCalledWith(
+      'aa',
+      expect.not.objectContaining({ timeoutMs: expect.anything() }),
+    );
+  });
+
+  it('frida_memory_scan async:true without a taskManager falls back to synchronous scan', async () => {
+    const memoryScan = vi.fn(async () => []);
+    const session = makeFakeSession({ memoryScan });
+    const handlers = new FridaHandlers(makeState(undefined, session));
+
+    const res = parse(
+      await handlers.handleFridaMemoryScan({
+        sessionId: 's1',
+        pattern: 'aa',
+        async: true,
+      } as Record<string, unknown>),
+    );
+
+    expect(res.success).toBe(true);
+    expect(res.taskId).toBeUndefined();
+    expect(memoryScan).toHaveBeenCalledTimes(1);
+  });
+
+  it('frida_run_script with async:true creates a task carrying the script execution', async () => {
+    const tm = new TaskManager();
+    const executeScript = vi.fn(async () => ({ output: 'hello' }));
+    const session = makeFakeSession({ executeScript });
+    const handlers = new FridaHandlers(makeState(tm, session));
+
+    const res = parse(
+      await handlers.handleFridaRunScript({
+        sessionId: 's1',
+        script: 'console.log("hi")',
+        async: true,
+      } as Record<string, unknown>),
+    );
+
+    expect(res.success).toBe(true);
+    expect(res.async).toBe(true);
+    expect(typeof res.taskId).toBe('string');
+
+    const payload = tm.getTaskPayload<{ output: string }>(res.taskId as string);
+    expect(payload?.status).toBe('completed');
+    expect(payload?.result?.output).toBe('hello');
+    expect(executeScript).toHaveBeenCalledWith(
+      'console.log("hi")',
+      expect.objectContaining({ timeoutMs: 5 * 60_000 }),
+    );
+  });
+
+  it('availability/session failures still fail fast before any task is created', async () => {
+    const tm = new TaskManager();
+    const session = makeFakeSession({
+      getAvailability: vi.fn(async () => ({ available: false, reason: 'frida missing' })),
+    });
+    const handlers = new FridaHandlers(makeState(tm, session));
+
+    const res = parse(
+      await handlers.handleFridaMemoryScan({
+        sessionId: 's1',
+        pattern: 'aa',
+        async: true,
+      } as Record<string, unknown>),
+    );
+
+    expect(res.success).toBe(false);
+    expect(res.available).toBe(false);
+    expect(res.taskId).toBeUndefined();
+    expect(tm.listTasks()).toHaveLength(0);
+  });
+});

--- a/tests/server/domains/binary-instrument/frida-task.test.ts
+++ b/tests/server/domains/binary-instrument/frida-task.test.ts
@@ -85,6 +85,28 @@ describe('FridaHandlers — task mode (MCP 2.0 Tasks retrofit)', () => {
     );
   });
 
+  it('frida_memory_scan task cancellation aborts the executor signal', async () => {
+    const tm = new TaskManager();
+    let seen: AbortSignal | undefined;
+    const memoryScan = vi.fn(async (_pattern: string, opts: { signal?: AbortSignal }) => {
+      seen = opts.signal;
+      await new Promise((r) => setTimeout(r, 200));
+      return [];
+    });
+    const session = makeFakeSession({ memoryScan });
+    const handlers = new FridaHandlers(makeState(tm, session));
+
+    const res = parse(
+      await handlers.handleFridaMemoryScan({
+        sessionId: 's1',
+        pattern: 'aa',
+        async: true,
+      } as Record<string, unknown>),
+    );
+    await tm.cancelTask(res.taskId as string);
+    expect(seen?.aborted).toBe(true);
+  });
+
   it('frida_memory_scan without async keeps the synchronous behavior (no task)', async () => {
     const tm = new TaskManager();
     const memoryScan = vi.fn(async () => [{ address: '0x1', size: 1 }]);

--- a/tests/server/domains/protocol-analysis/pcapng-read-task.test.ts
+++ b/tests/server/domains/protocol-analysis/pcapng-read-task.test.ts
@@ -1,0 +1,98 @@
+import { mkdtemp, rm, writeFile as fsWriteFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ProtocolAnalysisHandlers } from '@server/domains/protocol-analysis/handlers';
+import { TaskManager } from '@server/tasks/TaskManager';
+import { buildPcapng } from '@server/domains/protocol-analysis/handlers/shared/network-packet/pcapng-writer';
+import type { PcapngWriteInput } from '@server/domains/protocol-analysis/handlers/shared/network-packet/pcapng';
+
+describe('ProtocolAnalysisHandlers — handlePcapngRead async (MCP 2.0 Tasks)', () => {
+  const eventBus = { emit: vi.fn() } as any;
+  const tempDirs: string[] = [];
+  let handlers: ProtocolAnalysisHandlers;
+  let taskManager: TaskManager;
+
+  const writeSample = async (): Promise<string> => {
+    const input: PcapngWriteInput = {
+      endianness: 'little',
+      interfaces: [{ linkType: 1 }],
+      packets: [{ dataHex: 'aabbccdd' }],
+    };
+    const dir = await mkdtemp(join(tmpdir(), 'pcapng-task-'));
+    tempDirs.push(dir);
+    const path = join(dir, 'sample.pcapng');
+    await fsWriteFile(path, buildPcapng(input));
+    return path;
+  };
+
+  beforeEach(() => {
+    eventBus.emit.mockClear();
+    taskManager = new TaskManager();
+    // 4th ctor arg — the MCP 2.0 Tasks retrofit wiring from the manifest.
+    handlers = new ProtocolAnalysisHandlers(undefined, undefined, eventBus, taskManager);
+  });
+
+  afterEach(async () => {
+    while (tempDirs.length > 0) {
+      const dir = tempDirs.pop();
+      if (dir) await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('async:true returns a taskId immediately and the task completes with the parse result', async () => {
+    const path = await writeSample();
+
+    const res = await handlers.handlePcapngRead({ path, async: true });
+
+    expect(res.success).toBe(true);
+    expect(res.async).toBe(true);
+    expect(typeof res.taskId).toBe('string');
+    expect(res.blockCount).toBe(0); // payload is delivered via the task, not inline
+
+    // Poll briefly until the background parse settles.
+    let payload = taskManager.getTaskPayload<{ blockCount: number; packets: unknown[] }>(
+      res.taskId!,
+    );
+    for (let i = 0; i < 50 && payload?.status === 'working'; i++) {
+      await new Promise((r) => setTimeout(r, 20));
+      payload = taskManager.getTaskPayload<{ blockCount: number; packets: unknown[] }>(res.taskId!);
+    }
+    expect(payload?.status).toBe('completed');
+    expect(payload?.result?.blockCount).toBe(3); // SHB + IDB + EPB
+    expect(payload?.result?.packets).toHaveLength(1);
+  });
+
+  it('async without a taskManager falls back to the synchronous parse', async () => {
+    const path = await writeSample();
+    const legacy = new ProtocolAnalysisHandlers(undefined, undefined, eventBus);
+
+    const res = await legacy.handlePcapngRead({ path, async: true });
+
+    expect(res.success).toBe(true);
+    expect(res.async).toBeUndefined();
+    expect(res.blockCount).toBe(3);
+  });
+
+  it('sync path (no async flag) behaves exactly as before the retrofit', async () => {
+    const path = await writeSample();
+
+    const res = await handlers.handlePcapngRead({ path });
+
+    expect(res.success).toBe(true);
+    expect(res.async).toBeUndefined();
+    expect(res.blockCount).toBe(3);
+    expect(res.packets).toHaveLength(1);
+  });
+
+  it('task mode surfaces parse failures through the task payload', async () => {
+    const res = await handlers.handlePcapngRead({ path: 'Z:/nope/missing.pcapng', async: true });
+
+    expect(res.success).toBe(true);
+    // Give the executor a beat to reject before inspecting the payload.
+    await new Promise((r) => setTimeout(r, 50));
+    const payload = taskManager.getTaskPayload(res.taskId!);
+    expect(payload?.status).toBe('failed');
+    expect(String(payload?.error)).toBeTruthy();
+  });
+});

--- a/tests/server/tasks/TaskManager.test.ts
+++ b/tests/server/tasks/TaskManager.test.ts
@@ -158,6 +158,23 @@ describe('TaskManager (MCP 2.0 Tasks Protocol)', () => {
     expect(record?.error).toContain('maxWorkingAgeMs');
   });
 
+  it('aborts the execution-context signal on cancellation', async () => {
+    const manager = new TaskManager();
+    let observed: AbortSignal | undefined;
+    const task = await manager.createTask({
+      name: 'cancellable_scan',
+      executor: async (ctx) => {
+        observed = ctx.signal;
+        await new Promise((r) => setTimeout(r, 200));
+        return 'done';
+      },
+    });
+
+    expect(observed?.aborted).toBe(false);
+    await manager.cancelTask(task.taskId);
+    expect(observed?.aborted).toBe(true);
+  });
+
   it('hides tasks from callers of a different owning session', async () => {
     const { runWithToolRequestContext } = await import('@server/runtime/ToolRequestContext');
     const manager = new TaskManager();


### PR DESCRIPTION
## Summary
Adds MCP 2.0 async task modes to the three long-running tools, plus real cancellation:

- `frida_memory_scan`, `frida_run_script`, `pcapng_read` accept task mode (return a task handle immediately, poll for results)
- `cancelTask` now propagates an `AbortSignal` that actually kills the spawned frida CLI child processes (real cancellation, not just state change)

## Context
Part of the mcp2 task series: #123 (scheduler) and #126 (JIT validators) are already merged; this is the remaining piece of that stack, rebased on current master (merge-clean, no conflicts).

## Verification
- `pnpm test -- tests/server/domains/binary-instrument` (frida task tests)
- `pnpm test -- tests/server/tasks`

## Summary by Sourcery

Enable MCP 2.0 task execution and real cancellation for long-running Frida and PCAPNG tools.

New Features:
- Add asynchronous task-mode execution to Frida memory scans, Frida scripts, and PCAPNG reads with task polling and progress reporting.

Bug Fixes:
- Make task cancellation abort active work, including terminating spawned Frida CLI processes instead of only updating task state.

Enhancements:
- Support configurable, bounded longer timeouts for asynchronous Frida operations while preserving synchronous behavior and fallback paths.
- Refactor PCAPNG parsing into a reusable cancellable core for synchronous and background execution.

Tests:
- Add coverage for asynchronous Frida and PCAPNG task execution, timeout handling, cancellation propagation, fallback behavior, and task failures.