### PR TITLE
test(env-contract): file-level 180s timeout for corpus-scanning tests

### DIFF
--- a/tests/scripts/env-example.test.ts
+++ b/tests/scripts/env-example.test.ts
@@ -8,6 +8,11 @@ import {
   collectTypedEnvironmentReaders,
 } from './env-example-contract';
 
+// Every test in this file Babel-parses the whole src/ corpus; under coverage
+// instrumentation the scan roughly doubles and exceeds the 30s default on
+// slower runners.
+vi.setConfig({ testTimeout: 180_000 });
+
 interface EnvExampleEntry {
   key: string;
   rawValue: string;


### PR DESCRIPTION
## Summary
Adds a file-level 180s Vitest timeout to the env-contract tests that scan the full env example corpus — these exceed the default 5s per-test timeout on slower CI runners and flake on timeout.

## Verification
- `pnpm test -- tests/scripts/env-example.test.ts`

## Summary by Sourcery

Increase the env-contract test timeout to make full corpus scanning reliable on slower CI runners.

Bug Fixes:
- Prevent corpus-scanning env-contract tests from timing out on slower or coverage-instrumented CI runners.

Tests:
- Increase the Vitest timeout for the env example contract test file to accommodate full corpus scans.