### PR TITLE
chore(release): SLSA Phase 1 — id-token:write + --provenance

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -6,8 +6,24 @@ on:
     tags:
       - 'v*'
 
+# SLSA Phase 1 (npm Trusted Publishing):
+#   - `id-token: write` is REQUIRED to let `npm publish --provenance` obtain
+#     a GitHub OIDC token and request a Sigstore Fulcio signing certificate.
+#   - `contents: read` stays for checkout/tag validation.
+#   - Both jobs below inherit this block — no per-job override needed.
+#
+# REMAINING MANUAL STEP (NOT in code):
+#   Configure the Trusted Publisher on npmjs.com for both
+#     @jshookmcp/jshook          https://www.npmjs.com/package/@jshookmcp/jshook/settings
+#     @jshookmcp/extension-sdk   https://www.npmjs.com/package/@jshookmcp/extension-sdk/settings
+#   Add a GitHub Actions trusted publisher pointing at
+#     org: vmoranv, repo: jshookmcp, workflow: publish-packages.yml.
+#   Until that UI step is done, OIDC auth will fail and the publish job will
+#   fall back to NODE_AUTH_TOKEN below (kept intentionally as a bootstrap
+#   safety net during the migration window).
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   publish-root:
@@ -57,8 +73,13 @@ jobs:
         run: |
           ROOT_TARBALL="$(find .release-artifacts -maxdepth 1 -name '*.tgz' -print -quit)"
           test -n "$ROOT_TARBALL"
-          pnpm publish "$ROOT_TARBALL" --no-git-checks
+          # `--provenance` enables npm SLSA Build L1 attestation via Sigstore Fulcio.
+          # Requires `id-token: write` permission (set at workflow level above).
+          pnpm publish "$ROOT_TARBALL" --provenance --no-git-checks
         env:
+          # Bootstrap-only fallback. Once the Trusted Publisher UI is configured
+          # on npmjs.com (see file header), this env becomes redundant — npm CLI
+          # will use the OIDC token from the runner instead.
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   publish-extension-sdk:
@@ -113,6 +134,11 @@ jobs:
         run: |
           SDK_TARBALL="$(find .release-artifacts-sdk -maxdepth 1 -name '*.tgz' -print -quit)"
           test -n "$SDK_TARBALL"
-          pnpm publish "$SDK_TARBALL" --no-git-checks
+          # `--provenance` enables npm SLSA Build L1 attestation via Sigstore Fulcio.
+          # Requires `id-token: write` permission (set at workflow level above).
+          pnpm publish "$SDK_TARBALL" --provenance --no-git-checks
         env:
+          # Bootstrap-only fallback. Once the Trusted Publisher UI is configured
+          # on npmjs.com (see file header), this env becomes redundant — npm CLI
+          # will use the OIDC token from the runner instead.
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
Split out from the mislabeled PR #133 (`feat/minimal-npx-install`, closed). Adds SLSA Phase 1 supply-chain hardening to the package publish workflow: grants `id-token: write` and passes `--provenance` to the publish step.

## Changes
- `.github/workflows/publish-packages.yml`: add `permissions.id-token: write`, pass `--provenance` to the publish command.

## Notes
- Pure CI/release config change; no runtime code affected.
- Base is current upstream `master`. Diff vs `master` is exactly this one file.
- Local `pre-push` lefthook could not run (broken `corepack` shim in this env); typecheck was verified manually via `pnpm run typecheck`.

## Related
- Part of splitting #133's bundle into clean PRs (see also the mcp2 infra PR #146).

## Summary by Sourcery

Enable provenance-backed publishing for both npm packages through GitHub Actions.

Enhancements:
- Harden package publishing with npm provenance attestations as part of SLSA Phase 1 supply-chain security.

CI:
- Grant the publish workflow GitHub OIDC token permissions and enable provenance generation for both published packages while retaining token authentication during migration.