### PR TITLE
fix(utils): serialize concurrent InstanceRegistry registrations and default-encrypt sensitive artifacts (OPSEC)

### DIFF
--- a/src/utils/InstanceRegistry.ts
+++ b/src/utils/InstanceRegistry.ts
@@ -1,6 +1,6 @@
 /** Tracks live jshook server processes to make stdio process pile-ups visible and controllable. */
 import { unlinkSync } from 'node:fs';
-import { mkdir, readdir, readFile, rm, stat, unlink, writeFile } from 'node:fs/promises';
+import { mkdir, readdir, readFile, rename, rm, stat, unlink, writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
 import { JSHOOK_INSTANCE_WARN_AT, JSHOOK_MAX_INSTANCES } from '@src/constants';
@@ -35,9 +35,15 @@ function recordPath(pid: number): string {
 
 const registrationLockPath = () => resolve(instancesDir(), '.register-lock');
 
+/** Acquire-wait ceiling for the registration lock (ops-adjustable, tests shrink it). */
+function registrationLockTimeoutMs(): number {
+  const raw = Number(readEnvString('JSHOOK_REGISTRATION_LOCK_TIMEOUT_MS', ''));
+  return Number.isFinite(raw) && raw > 0 ? raw : 5_000;
+}
+
 async function withRegistrationLock<T>(callback: () => Promise<T>): Promise<T> {
   await mkdir(instancesDir(), { recursive: true });
-  const deadline = Date.now() + 5_000;
+  const deadline = Date.now() + registrationLockTimeoutMs();
 
   while (true) {
     try {
@@ -53,7 +59,18 @@ async function withRegistrationLock<T>(callback: () => Promise<T>): Promise<T> {
       try {
         const lockInfo = await stat(registrationLockPath());
         if (Date.now() - lockInfo.mtimeMs > 30_000) {
-          await rm(registrationLockPath(), { recursive: true, force: true });
+          // Stale takeover must be atomic: two waiters can both observe the
+          // same stale lock, and a plain rm would let the slower waiter
+          // delete the lock the faster one just re-created (double
+          // ownership). rename() only succeeds for exactly one waiter; the
+          // losers get ENOENT and re-enter the acquire loop.
+          const stalePath = `${registrationLockPath()}.stale-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+          try {
+            await rename(registrationLockPath(), stalePath);
+          } catch {
+            continue;
+          }
+          await rm(stalePath, { recursive: true, force: true }).catch(() => {});
           continue;
         }
       } catch {
@@ -61,7 +78,14 @@ async function withRegistrationLock<T>(callback: () => Promise<T>): Promise<T> {
       }
 
       if (Date.now() >= deadline) {
-        throw new Error('timed out waiting for the instance registration lock', { cause: error });
+        // Fail open: registration is best-effort telemetry, and a held-up
+        // lock (crashed holder inside the rename window, AV scanner holding
+        // the dir on Windows) must not stop the server from booting. Run
+        // unlocked and say so loudly.
+        logger.warn(
+          '[instances] timed out waiting for the instance registration lock — registering without it',
+        );
+        return await callback();
       }
       await delay(25);
     }
@@ -70,7 +94,10 @@ async function withRegistrationLock<T>(callback: () => Promise<T>): Promise<T> {
   try {
     return await callback();
   } finally {
-    await rm(registrationLockPath(), { recursive: true, force: true });
+    // Best-effort release: on Windows a concurrent scanner can hold the dir
+    // (EBUSY/EPERM). Swallowing this leaves the lock to the 30s stale
+    // reaper instead of failing a registration that already succeeded.
+    await rm(registrationLockPath(), { recursive: true, force: true }).catch(() => {});
   }
 }
 

--- a/src/utils/InstanceRegistry.ts
+++ b/src/utils/InstanceRegistry.ts
@@ -1,7 +1,8 @@
 /** Tracks live jshook server processes to make stdio process pile-ups visible and controllable. */
 import { unlinkSync } from 'node:fs';
-import { mkdir, readdir, readFile, unlink, writeFile } from 'node:fs/promises';
+import { mkdir, readdir, readFile, rm, stat, unlink, writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
 import { JSHOOK_INSTANCE_WARN_AT, JSHOOK_MAX_INSTANCES } from '@src/constants';
 import { getStateDir } from '@server/persistence/RuntimeSnapshotScheduler';
 import { logger } from '@utils/logger';
@@ -30,6 +31,47 @@ function instancesDir(): string {
 
 function recordPath(pid: number): string {
   return resolve(instancesDir(), `${pid}.json`);
+}
+
+const registrationLockPath = () => resolve(instancesDir(), '.register-lock');
+
+async function withRegistrationLock<T>(callback: () => Promise<T>): Promise<T> {
+  await mkdir(instancesDir(), { recursive: true });
+  const deadline = Date.now() + 5_000;
+
+  while (true) {
+    try {
+      await mkdir(registrationLockPath());
+      break;
+    } catch (error) {
+      if (
+        !(typeof error === 'object' && error !== null && 'code' in error && error.code === 'EEXIST')
+      ) {
+        throw new Error('failed to acquire the instance registration lock', { cause: error });
+      }
+
+      try {
+        const lockInfo = await stat(registrationLockPath());
+        if (Date.now() - lockInfo.mtimeMs > 30_000) {
+          await rm(registrationLockPath(), { recursive: true, force: true });
+          continue;
+        }
+      } catch {
+        // The lock was released between mkdir and stat; retry immediately.
+      }
+
+      if (Date.now() >= deadline) {
+        throw new Error('timed out waiting for the instance registration lock', { cause: error });
+      }
+      await delay(25);
+    }
+  }
+
+  try {
+    return await callback();
+  } finally {
+    await rm(registrationLockPath(), { recursive: true, force: true });
+  }
 }
 
 function isProcessAlive(pid: number): boolean {
@@ -107,72 +149,74 @@ export async function registerServerInstance(options?: {
     profile: options?.profile ?? readEnvString('MCP_TOOL_PROFILE', 'search', { trim: true }),
     argv0: process.argv[1] ?? process.argv0 ?? 'jshook',
   };
-  const peers = await listLiveInstances(self.pid);
-  const liveCount = peers.length + 1;
+  return withRegistrationLock(async () => {
+    const peers = await listLiveInstances(self.pid);
+    const liveCount = peers.length + 1;
 
-  if (JSHOOK_MAX_INSTANCES > 0 && liveCount > JSHOOK_MAX_INSTANCES) {
-    const peerSummary = peers
-      .map((peer) => `${peer.pid}(${peer.profile}/${peer.transport})`)
-      .join(', ');
-    throw new Error(
-      `jshook instance limit reached: ${liveCount} > JSHOOK_MAX_INSTANCES=${JSHOOK_MAX_INSTANCES}. ` +
-        `Live peers: ${peerSummary || '(none)'}. Stop unused MCP hosts, raise the limit, or share one ` +
-        `HTTP server across clients.`,
-    );
-  }
-
-  try {
-    await mkdir(instancesDir(), { recursive: true });
-    await writeFile(recordPath(self.pid), JSON.stringify(self, null, 2), 'utf8');
-  } catch (error) {
-    logger.warn(
-      `[instance] failed to write instance record: ${error instanceof Error ? error.message : String(error)}`,
-    );
-  }
-
-  // Post-registration re-check: closes the check-then-act race window where
-  // concurrent registrations all pass the pre-check above and collectively
-  // exceed the cap. Roll our own record back when the cap is exceeded.
-  const postPeers = await listLiveInstances(self.pid);
-  const postLiveCount = postPeers.length + 1;
-  if (JSHOOK_MAX_INSTANCES > 0 && postLiveCount > JSHOOK_MAX_INSTANCES) {
-    await unregisterServerInstance(self.pid).catch(() => undefined);
-    const peerSummary = postPeers
-      .map((peer) => `${peer.pid}(${peer.profile}/${peer.transport})`)
-      .join(', ');
-    throw new Error(
-      `jshook instance limit reached: ${postLiveCount} > JSHOOK_MAX_INSTANCES=${JSHOOK_MAX_INSTANCES}. ` +
-        `Live peers: ${peerSummary || '(none)'}. Stop unused MCP hosts, raise the limit, or share one ` +
-        `HTTP server across clients.`,
-    );
-  }
-
-  const warned = postLiveCount >= Math.max(1, JSHOOK_INSTANCE_WARN_AT);
-  if (warned) {
-    const peerSummary = postPeers
-      .map((peer) => `pid=${peer.pid} profile=${peer.profile} transport=${peer.transport}`)
-      .join('; ');
-    logger.warn(
-      `[instance] ${postLiveCount} live jshook processes detected (self pid=${self.pid} rss=${formatRssMb()}). ` +
-        `Each stdio MCP host owns a separate process. Peers: ${peerSummary || '(none)'}. ` +
-        `Disable unused MCP entries, configure JSHOOK_MAX_INSTANCES, or use one shared HTTP server.`,
-    );
-  } else {
-    logger.info(
-      `[instance] registered pid=${self.pid} transport=${self.transport} profile=${self.profile} ` +
-        `rss=${formatRssMb()} peers=${postPeers.length}`,
-    );
-  }
-
-  process.once('exit', () => {
-    try {
-      unlinkSync(recordPath(self.pid));
-    } catch {
-      // The async shutdown path may already have removed it.
+    if (JSHOOK_MAX_INSTANCES > 0 && liveCount > JSHOOK_MAX_INSTANCES) {
+      const peerSummary = peers
+        .map((peer) => `${peer.pid}(${peer.profile}/${peer.transport})`)
+        .join(', ');
+      throw new Error(
+        `jshook instance limit reached: ${liveCount} > JSHOOK_MAX_INSTANCES=${JSHOOK_MAX_INSTANCES}. ` +
+          `Live peers: ${peerSummary || '(none)'}. Stop unused MCP hosts, raise the limit, or share one ` +
+          `HTTP server across clients.`,
+      );
     }
-  });
 
-  return { self, livePeers: postPeers, liveCount: postLiveCount, warned, blocked: false };
+    try {
+      await mkdir(instancesDir(), { recursive: true });
+      await writeFile(recordPath(self.pid), JSON.stringify(self, null, 2), 'utf8');
+    } catch (error) {
+      logger.warn(
+        `[instance] failed to write instance record: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+
+    // Post-registration re-check: closes the check-then-act race window where
+    // concurrent registrations all pass the pre-check above and collectively
+    // exceed the cap. Roll our own record back when the cap is exceeded.
+    const postPeers = await listLiveInstances(self.pid);
+    const postLiveCount = postPeers.length + 1;
+    if (JSHOOK_MAX_INSTANCES > 0 && postLiveCount > JSHOOK_MAX_INSTANCES) {
+      await unregisterServerInstance(self.pid).catch(() => undefined);
+      const peerSummary = postPeers
+        .map((peer) => `${peer.pid}(${peer.profile}/${peer.transport})`)
+        .join(', ');
+      throw new Error(
+        `jshook instance limit reached: ${postLiveCount} > JSHOOK_MAX_INSTANCES=${JSHOOK_MAX_INSTANCES}. ` +
+          `Live peers: ${peerSummary || '(none)'}. Stop unused MCP hosts, raise the limit, or share one ` +
+          `HTTP server across clients.`,
+      );
+    }
+
+    const warned = postLiveCount >= Math.max(1, JSHOOK_INSTANCE_WARN_AT);
+    if (warned) {
+      const peerSummary = postPeers
+        .map((peer) => `pid=${peer.pid} profile=${peer.profile} transport=${peer.transport}`)
+        .join('; ');
+      logger.warn(
+        `[instance] ${postLiveCount} live jshook processes detected (self pid=${self.pid} rss=${formatRssMb()}). ` +
+          `Each stdio MCP host owns a separate process. Peers: ${peerSummary || '(none)'}. ` +
+          `Disable unused MCP entries, configure JSHOOK_MAX_INSTANCES, or use one shared HTTP server.`,
+      );
+    } else {
+      logger.info(
+        `[instance] registered pid=${self.pid} transport=${self.transport} profile=${self.profile} ` +
+          `rss=${formatRssMb()} peers=${postPeers.length}`,
+      );
+    }
+
+    process.once('exit', () => {
+      try {
+        unlinkSync(recordPath(self.pid));
+      } catch {
+        // The async shutdown path may already have removed it.
+      }
+    });
+
+    return { self, livePeers: postPeers, liveCount: postLiveCount, warned, blocked: false };
+  });
 }
 
 export async function unregisterServerInstance(pid = process.pid): Promise<void> {

--- a/src/utils/artifacts.ts
+++ b/src/utils/artifacts.ts
@@ -23,6 +23,30 @@ export type ArtifactCategory =
   | 'tmp'
   | 'heap-snapshots';
 
+/**
+ * Categories whose default artifact body is treated as sensitive and written
+ * with an AES-256-GCM envelope unless the caller explicitly opts out
+ * (`encrypt: false`). The list is the OPSEC-driven subset of `ArtifactCategory`
+ * — traces, profiles, dumps, captures, sessions, and HAR all routinely contain
+ * secrets, PII, or session-internal state that should never reach disk in
+ * plaintext form.
+ *
+ * `heap-snapshots` is intentionally excluded even though it is sensitive in
+ * the same sense: `v8_heap_snapshot_export` writes `.heapsnapshot` files so
+ * Chrome DevTools' Memory panel can load them directly, and forcing
+ * encryption would break that contract. Callers writing heap snapshots must
+ * use `heap-snapshots` (no auto-encryption) or pass `encrypt: true` explicitly
+ * for a sealed backup.
+ */
+const SENSITIVE_CATEGORIES: ReadonlySet<ArtifactCategory> = new Set([
+  'dumps',
+  'traces',
+  'profiles',
+  'captures',
+  'sessions',
+  'har',
+]);
+
 const ARTIFACT_BASE = 'artifacts';
 
 /**
@@ -209,27 +233,32 @@ export function getArtifactDir(category: ArtifactCategory): string {
 
 /**
  * Write artifact content to a path already reserved by resolveArtifactPath().
- * When `encrypt` is set, the content is wrapped in an AES-256-GCM envelope
- * (see @utils/crypto/ephemeralCipher) instead of written as plaintext, and
- * the caller gets back the hex key needed to decrypt it later — nothing is
- * persisted that would let a disk-forensics pass recover the key on its own.
  *
- * Deliberately opt-in per call rather than defaulted by category: some
- * categories that hold sensitive content (e.g. heap-snapshots) are also
- * consumed by external tools in plaintext form by design — v8_heap_snapshot_export
- * writes a .heapsnapshot file specifically so Chrome DevTools' Memory panel
- * can load it directly, so forcing encryption there would break that tool's
- * stated contract. Callers that hold genuinely sensitive artifacts (memory
- * dumps, captured secrets) should pass `encrypt: true` explicitly.
+ * Encryption policy:
+ * - `encrypt: true`  → always write an AES-256-GCM envelope (mode 0o600).
+ * - `encrypt: false` → always write plaintext, even for sensitive categories
+ *                      (explicit override; callers must justify the choice).
+ * - omitted + `category` in `SENSITIVE_CATEGORIES` → encrypt by default
+ *                      (OPSEC default; covers dumps/traces/profiles/captures/
+ *                      sessions/har).
+ * - omitted + non-sensitive category or no category → write plaintext.
+ *
+ * The encryption key is returned in hex form to the caller; it is never
+ * persisted to disk, so a disk-forensics pass on the artifact alone cannot
+ * recover the plaintext.
  */
 export async function writeArtifactContent(
   absolutePath: string,
   content: string | Uint8Array,
-  options?: { encrypt?: boolean },
+  options?: { encrypt?: boolean; category?: ArtifactCategory },
 ): Promise<{ encryptionKeyHex?: string }> {
   const buffer = typeof content === 'string' ? Buffer.from(content, 'utf8') : Buffer.from(content);
 
-  if (!options?.encrypt) {
+  const shouldEncrypt =
+    options?.encrypt ??
+    (options?.category !== undefined && SENSITIVE_CATEGORIES.has(options.category));
+
+  if (!shouldEncrypt) {
     await writeFile(absolutePath, buffer);
     return {};
   }

--- a/tests/utils/InstanceRegistry.lock.test.ts
+++ b/tests/utils/InstanceRegistry.lock.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdir, mkdtemp, readdir, rm } from 'node:fs/promises';
+import { utimesSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+describe('utils/InstanceRegistry registration lock', () => {
+  let stateDir: string;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    stateDir = await mkdtemp(join(tmpdir(), 'jshook-state-'));
+    process.env.JSHOOK_STATE_DIR = stateDir;
+  });
+
+  afterEach(async () => {
+    delete process.env.JSHOOK_STATE_DIR;
+    vi.unstubAllEnvs();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    await rm(stateDir, { recursive: true, force: true });
+  });
+
+  const lockDir = () => join(stateDir, 'instances', '.register-lock');
+
+  it('serializes concurrent registrations — every writer lands', async () => {
+    vi.doMock('@src/constants', async (importOriginal) => ({
+      ...(await importOriginal<typeof import('@src/constants')>()),
+      JSHOOK_INSTANCE_WARN_AT: 99,
+      JSHOOK_MAX_INSTANCES: 0,
+    }));
+    const { registerServerInstance } = await import('@utils/InstanceRegistry');
+
+    const results = await Promise.all(
+      Array.from({ length: 5 }, (_, i) =>
+        registerServerInstance({ transport: `stdio-${i}`, profile: 'workflow' }),
+      ),
+    );
+
+    expect(results).toHaveLength(5);
+    results.forEach((r) => {
+      expect(r.blocked).toBe(false);
+      expect(r.self.pid).toBe(process.pid);
+    });
+    // Records are keyed by pid: the concurrent writers converge on one
+    // consistent record instead of interleaving partial writes.
+    const records = await readdir(join(stateDir, 'instances'));
+    const jsonRecords = records.filter((f) => f.endsWith('.json'));
+    expect(jsonRecords).toEqual([`${process.pid}.json`]);
+  });
+
+  it('takes over a stale lock atomically and registers', async () => {
+    vi.doMock('@src/constants', async (importOriginal) => ({
+      ...(await importOriginal<typeof import('@src/constants')>()),
+      JSHOOK_INSTANCE_WARN_AT: 99,
+      JSHOOK_MAX_INSTANCES: 0,
+    }));
+    const { registerServerInstance } = await import('@utils/InstanceRegistry');
+
+    await mkdir(join(stateDir, 'instances'), { recursive: true });
+    await mkdir(lockDir());
+    // Backdate beyond the 30s staleness window.
+    const stale = new Date(Date.now() - 60_000);
+    utimesSync(lockDir(), stale, stale);
+
+    const result = await registerServerInstance({ transport: 'stdio', profile: 'workflow' });
+    expect(result.self.pid).toBe(process.pid);
+    // The stale lock must be gone (renamed away + removed).
+    const entries = await readdir(join(stateDir, 'instances'));
+    expect(entries.some((f) => f.startsWith('.register-lock'))).toBe(false);
+  });
+
+  it('two waiters racing on a stale lock cannot double-own or lose the lock', async () => {
+    vi.doMock('@src/constants', async (importOriginal) => ({
+      ...(await importOriginal<typeof import('@src/constants')>()),
+      JSHOOK_INSTANCE_WARN_AT: 99,
+      JSHOOK_MAX_INSTANCES: 0,
+    }));
+    const { registerServerInstance } = await import('@utils/InstanceRegistry');
+
+    await mkdir(join(stateDir, 'instances'), { recursive: true });
+    await mkdir(lockDir());
+    const stale = new Date(Date.now() - 60_000);
+    utimesSync(lockDir(), stale, stale);
+
+    const results = await Promise.all([
+      registerServerInstance({ transport: 'stdio-a', profile: 'workflow' }),
+      registerServerInstance({ transport: 'stdio-b', profile: 'workflow' }),
+    ]);
+
+    // Both must complete through the lock (not the warn-only fallback —
+    // neither saw the 5s deadline because the takeover unblocked them).
+    // Records are keyed by pid, so two same-process registrations converge
+    // on one record file.
+    const records = await readdir(join(stateDir, 'instances'));
+    const jsonRecords = records.filter((f) => f.endsWith('.json'));
+    expect(jsonRecords).toEqual([`${process.pid}.json`]);
+    expect(results).toHaveLength(2);
+  });
+
+  it('degrades to warn-only (runs unlocked) when the lock deadline expires', async () => {
+    vi.doMock('@src/constants', async (importOriginal) => ({
+      ...(await importOriginal<typeof import('@src/constants')>()),
+      JSHOOK_INSTANCE_WARN_AT: 99,
+      JSHOOK_MAX_INSTANCES: 0,
+    }));
+    // Shrink the acquire-wait ceiling instead of mocking the clock: the
+    // registry also calls Date.now for record reaping, so clock games would
+    // misfire the staleness branch.
+    process.env.JSHOOK_REGISTRATION_LOCK_TIMEOUT_MS = '1';
+
+    const { registerServerInstance } = await import('@utils/InstanceRegistry');
+    // vi.resetModules() re-instantiates the logger module — spy on the same
+    // instance the registry actually uses.
+    const { logger } = await import('@utils/logger');
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+
+    // A fresh (non-stale) lock held by a crashed holder.
+    await mkdir(join(stateDir, 'instances'), { recursive: true });
+    await mkdir(lockDir());
+
+    const result = await registerServerInstance({ transport: 'stdio', profile: 'workflow' });
+
+    expect(result.self.pid).toBe(process.pid);
+    // Registration ran WITHOUT the lock: the held lock is untouched and the
+    // degradation was announced.
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('registering without it'));
+    const entries = await readdir(join(stateDir, 'instances'));
+    expect(entries.some((f) => f === '.register-lock')).toBe(true);
+  });
+});

--- a/tests/utils/artifacts.test.ts
+++ b/tests/utils/artifacts.test.ts
@@ -258,4 +258,78 @@ describe('writeArtifactContent', () => {
     await writeArtifactContent(resolve(ROOT, 'artifacts/dumps/bin.dat'), bytes, { encrypt: true });
     expect(writeFile).toHaveBeenCalledTimes(1);
   });
+
+  it('auto-encrypts content for dumps, traces, profiles, captures, sessions, har categories', async () => {
+    const sensitiveCategories = [
+      'dumps',
+      'traces',
+      'profiles',
+      'captures',
+      'sessions',
+      'har',
+    ] as const;
+    for (const category of sensitiveCategories) {
+      vi.mocked(writeFile).mockClear();
+      const result = await writeArtifactContent(
+        resolve(ROOT, `artifacts/${category}/auto.txt`),
+        'sensitive payload',
+        { category },
+      );
+      expect(result.encryptionKeyHex, `category=${category} should default-encrypt`).toMatch(
+        /^[0-9a-f]{64}$/,
+      );
+      const [, writtenContent, writeOptions] = vi.mocked(writeFile).mock.calls[0]!;
+      expect(writeOptions, `category=${category} should write with 0o600`).toEqual({ mode: 0o600 });
+      const envelope = JSON.parse(writtenContent as string);
+      expect(envelope.algorithm, `category=${category} envelope`).toBe('aes-256-gcm');
+      expect(envelope.payload, `category=${category} ciphertext`).not.toContain(
+        'sensitive payload',
+      );
+    }
+  });
+
+  it('keeps plaintext for non-sensitive categories (reports, tmp, offloaded, wasm)', async () => {
+    const nonSensitiveCategories = ['reports', 'tmp', 'offloaded', 'wasm'] as const;
+    for (const category of nonSensitiveCategories) {
+      vi.mocked(writeFile).mockClear();
+      const result = await writeArtifactContent(
+        resolve(ROOT, `artifacts/${category}/plain.txt`),
+        'plain text',
+        { category },
+      );
+      expect(
+        result.encryptionKeyHex,
+        `category=${category} should NOT default-encrypt`,
+      ).toBeUndefined();
+      const [, writtenContent, writeOptions] = vi.mocked(writeFile).mock.calls[0]!;
+      expect(writeOptions, `category=${category} should write without mode`).toBeUndefined();
+      expect(writtenContent, `category=${category} content`).toEqual(
+        Buffer.from('plain text', 'utf8'),
+      );
+    }
+  });
+
+  it('keeps heap-snapshots plaintext for Chrome DevTools Memory panel compatibility', async () => {
+    const result = await writeArtifactContent(
+      resolve(ROOT, 'artifacts/heap-snapshots/snap.heapsnapshot'),
+      'binary heap data',
+      { category: 'heap-snapshots' },
+    );
+    expect(result.encryptionKeyHex).toBeUndefined();
+    const [, writtenContent, writeOptions] = vi.mocked(writeFile).mock.calls[0]!;
+    expect(writeOptions).toBeUndefined();
+    expect(writtenContent).toEqual(Buffer.from('binary heap data', 'utf8'));
+  });
+
+  it('allows explicit encrypt:false to opt out of default encryption on sensitive category', async () => {
+    const result = await writeArtifactContent(
+      resolve(ROOT, 'artifacts/dumps/override.bin'),
+      'overridden',
+      { category: 'dumps', encrypt: false },
+    );
+    expect(result.encryptionKeyHex).toBeUndefined();
+    const [, writtenContent, writeOptions] = vi.mocked(writeFile).mock.calls[0]!;
+    expect(writeOptions).toBeUndefined();
+    expect(writtenContent).toEqual(Buffer.from('overridden', 'utf8'));
+  });
 });


### PR DESCRIPTION
Split out from the mislabeled/closed PR #133 (`feat/minimal-npx-install`).

This PR contains only the `utils` correctness + OPSEC fixes:

- `src/utils/InstanceRegistry.ts`: serialize concurrent registrations (race fix).
- `src/utils/artifacts.ts`: default-encrypt sensitive artifacts at rest.
- `tests/utils/artifacts.test.ts`: regression coverage for the encryption path.

The i18n over-translation portion of #133 was already rejected as over-localization (PR #136, closed) and is intentionally dropped here. The mcp2 infrastructure (PR #146), SLSA release (PR #147), canvas domain, and browser/performance domain are split into their own independent PRs.

## Scope
- Purely additive + targeted fixes, parented on upstream `master` (`3be2ac04`).
- Diff vs master: 3 files, +222 / -75.
- No MCP 2.0 protocol-layer changes (these utils are shared infra, not protocol).

## Summary by Sourcery

Harden instance registration against concurrency races and protect sensitive artifacts with secure-by-default encryption.

Bug Fixes:
- Serialize concurrent instance registrations to prevent race conditions and preserve instance-limit enforcement.
- Default-encrypt sensitive artifact categories at rest while retaining explicit plaintext and heap-snapshot compatibility overrides.

Tests:
- Add regression coverage for registration-lock serialization, stale-lock recovery, timeout fallback, and artifact encryption policy.