### PR TITLE
fix(binary-instrument): close frida cancellation race + tree-kill the CLI child

### DIFF
--- a/src/modules/binary-instrument/FridaSession.ts
+++ b/src/modules/binary-instrument/FridaSession.ts
@@ -7,6 +7,14 @@ import { PrerequisiteError } from '@errors/PrerequisiteError';
 import { ToolError } from '@errors/ToolError';
 
 const FRIDA_MAX_BUFFER_BYTES = 5 * 1024 * 1024;
+/** Grace period between the SIGTERM and SIGKILL escalation on cancellation. */
+const FRIDA_KILL_ESCALATION_MS = 1_500;
+
+function abortError(message: string): Error {
+  const error = new Error(message);
+  error.name = 'AbortError';
+  return error;
+}
 
 export interface FridaScriptResult {
   output: string;
@@ -704,6 +712,16 @@ export class FridaSession {
     signal?: AbortSignal,
   ): Promise<CommandResult> {
     return new Promise((resolve, reject) => {
+      // The task may already be cancelled between the caller's check and
+      // this spawn (TaskManager awaits, availability probes) — never start
+      // work for an aborted task.
+      if (signal?.aborted) {
+        reject(abortError('Frida command aborted before spawn'));
+        return;
+      }
+
+      let escalationTimer: ReturnType<typeof setTimeout> | undefined;
+
       const child = execFile(
         file,
         args,
@@ -712,9 +730,16 @@ export class FridaSession {
           windowsHide: true,
           maxBuffer: FRIDA_MAX_BUFFER_BYTES,
           encoding: 'utf8',
+          // POSIX: lead a new process group so cancellation can signal the
+          // whole tree — in spawn mode the instrumented target is a
+          // grandchild of the frida CLI.
+          detached: process.platform !== 'win32',
         },
         (error, stdout, stderr) => {
           signal?.removeEventListener('abort', onAbort);
+          if (escalationTimer) {
+            clearTimeout(escalationTimer);
+          }
           if (error) {
             reject(error);
             return;
@@ -729,10 +754,44 @@ export class FridaSession {
 
       // Task cancellation must actually stop the CLI child — otherwise a
       // cancelled frida scan keeps burning CPU on the target for minutes.
+      // Kill the whole tree (Windows: taskkill /T; POSIX: process-group
+      // signal — the child was spawned detached) and escalate to SIGKILL
+      // so a frida CLI that swallows SIGTERM cannot outlive cancellation.
+      // All spawns here use argv arrays without a shell; PIDs come from
+      // our own child process, never from user input.
       function onAbort() {
-        child.kill();
+        if (child.pid === undefined) {
+          return;
+        }
+        if (process.platform === 'win32') {
+          execFile(
+            'taskkill',
+            ['/pid', String(child.pid), '/T', '/F'],
+            { windowsHide: true },
+            () => {},
+          );
+          return;
+        }
+        try {
+          process.kill(-child.pid, 'SIGTERM');
+        } catch {
+          child.kill('SIGTERM');
+        }
+        escalationTimer = setTimeout(() => {
+          try {
+            process.kill(-child.pid, 'SIGKILL');
+          } catch {
+            child.kill('SIGKILL');
+          }
+        }, FRIDA_KILL_ESCALATION_MS);
+        escalationTimer.unref();
       }
-      signal?.addEventListener('abort', onAbort, { once: true });
+
+      if (signal?.aborted) {
+        onAbort();
+      } else {
+        signal?.addEventListener('abort', onAbort, { once: true });
+      }
     });
   }
 }

--- a/tests/modules/binary-instrument/FridaSession.test.ts
+++ b/tests/modules/binary-instrument/FridaSession.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { FridaSession } from '@modules/binary-instrument/FridaSession';
 import { probeCommand } from '@modules/external/ToolProbe';
 
@@ -236,5 +236,130 @@ describe('FridaSession', () => {
     await session.attach('com.example.app');
     await session.executeScript('test');
     expect(execFile.mock.calls[execFile.mock.calls.length - 1]?.[1]).toContain('-n');
+  });
+});
+
+describe('FridaSession task cancellation', () => {
+  let session: FridaSession;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    session = new FridaSession();
+    (probeCommand as any).mockResolvedValue({
+      available: true,
+      path: '/usr/bin/frida',
+      version: '16.0.0',
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('never spawns a child when the signal is already aborted', async () => {
+    const execFile = await import('node:child_process').then((m) => m.execFile as any);
+    const controller = new AbortController();
+    controller.abort();
+
+    await session.attach('1234');
+    const callsBefore = execFile.mock.calls.length;
+    const result = await session.executeScript('test', { signal: controller.signal });
+
+    expect(result.error).toContain('aborted before spawn');
+    expect(execFile.mock.calls.length).toBe(callsBefore);
+  });
+
+  it('signals the whole process group and escalates to SIGKILL on cancel (POSIX)', async () => {
+    if (process.platform === 'win32') return; // covered by the Windows test below
+    const killSpy = vi.spyOn(process, 'kill').mockReturnValue(true);
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    let storedCb: ((err: Error | null, stdout: string, stderr: string) => void) | undefined;
+    const childKill = vi.fn();
+    const execFile = await import('node:child_process').then((m) => m.execFile as any);
+    execFile
+      .mockImplementationOnce((_f: any, _a: any, _o: any, cb: any) => {
+        // attach's own probe spawn — complete immediately
+        cb(null, '__frida_attach_ok__', '');
+      })
+      .mockImplementationOnce((_f: any, _a: any, _o: any, cb: any) => {
+        storedCb = cb;
+        return { pid: 4242, kill: childKill };
+      });
+
+    await session.attach('1234');
+    const pending = session.executeScript('long scan', { signal: controller.signal });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(storedCb).toBeTruthy();
+
+    controller.abort();
+    expect(killSpy).toHaveBeenCalledWith(-4242, 'SIGTERM');
+
+    await vi.advanceTimersByTimeAsync(1500);
+    expect(killSpy).toHaveBeenCalledWith(-4242, 'SIGKILL');
+
+    storedCb!(new Error('terminated'), '', '');
+    const result = await pending;
+    expect(result.error).toContain('terminated');
+  });
+
+  it('kills immediately when the signal aborts during spawn (race window)', async () => {
+    if (process.platform === 'win32') return;
+    const killSpy = vi.spyOn(process, 'kill').mockReturnValue(true);
+    const controller = new AbortController();
+    let storedCb: ((err: Error | null, stdout: string, stderr: string) => void) | undefined;
+    const execFile = await import('node:child_process').then((m) => m.execFile as any);
+    execFile
+      .mockImplementationOnce((_f: any, _a: any, _o: any, cb: any) => {
+        cb(null, '__frida_attach_ok__', '');
+      })
+      .mockImplementationOnce((_f: any, _a: any, _o: any, cb: any) => {
+        storedCb = cb;
+        controller.abort(); // lands between spawn and listener registration
+        return { pid: 4242, kill: vi.fn() };
+      });
+
+    await session.attach('1234');
+    const pending = session.executeScript('scan', { signal: controller.signal });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(killSpy).toHaveBeenCalledWith(-4242, 'SIGTERM');
+
+    storedCb!(new Error('terminated'), '', '');
+    await pending;
+  });
+
+  it('uses taskkill tree kill on Windows', async () => {
+    const execFile = await import('node:child_process').then((m) => m.execFile as any);
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    try {
+      const controller = new AbortController();
+      let storedCb: ((err: Error | null, stdout: string, stderr: string) => void) | undefined;
+      const childKill = vi.fn();
+      execFile
+        .mockImplementationOnce((_f: any, _a: any, _o: any, cb: any) => {
+          cb(null, '__frida_attach_ok__', '');
+        })
+        .mockImplementationOnce((_f: any, _a: any, _o: any, cb: any) => {
+          storedCb = cb;
+          return { pid: 4242, kill: childKill };
+        });
+
+      await session.attach('1234');
+      const pending = session.executeScript('scan', { signal: controller.signal });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      controller.abort();
+
+      const taskkillCall = execFile.mock.calls.find((c: any[]) => c[0] === 'taskkill');
+      expect(taskkillCall).toBeTruthy();
+      expect(taskkillCall![1]).toEqual(['/pid', '4242', '/T', '/F']);
+      expect(childKill).not.toHaveBeenCalled();
+
+      storedCb!(null, 'ok', '');
+      await pending;
+    } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+    }
   });
 });


### PR DESCRIPTION
Follow-up to #134 (merged with two review majors now on master).

## What changed

1. **Already-aborted signal still spawned an unkillable child** — `execFileUtf8` only registered an `abort` listener and never checked `signal.aborted`; a cancel landing between `createTask` and the spawn (executor awaits, availability probe) left frida running its full timeout. Now: reject with `AbortError` pre-spawn **and** re-check after spawn before listener registration.

2. **No tree kill** — `child.kill()` SIGTERMed only the direct child; in spawn mode (`-f`) the instrumented target is a grandchild and survived cancellation. Now:
   - POSIX: the CLI is spawned detached (own process group); cancel signals the whole group (`-pid`), escalating SIGTERM to SIGKILL after 1.5s
   - Windows: `taskkill /PID <pid> /T /F` (argv array, no shell; pid comes from our own child, never user input)

3. **Zero test coverage** on the headline path — added four tests: pre-aborted never spawns, mid-run group kill + SIGKILL escalation, abort-during-spawn race window, Windows taskkill tree kill.

## Verification

- `pnpm vitest run FridaSession` — 24 passed (6 previously uncovered cancel paths now covered)
- oxlint clean on touched files; typecheck clean

## Summary by Sourcery

Ensure cancelled Frida sessions stop reliably across platforms and race conditions.

Bug Fixes:
- Prevent Frida commands from spawning when cancellation has already occurred or from surviving cancellation due to child processes.
- Terminate the complete Frida process tree on cancellation, including SIGKILL escalation on POSIX and forced tree termination on Windows.

Tests:
- Add coverage for pre-spawn cancellation, process-group termination and escalation, the spawn cancellation race, and Windows tree termination.