### PR TITLE
fix(readme): post-merge CI fallout — markdownlint, anchor links, 404 badges + frida typecheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![MCP](https://img.shields.io/badge/MCP-current-8A2BE2.svg)](https://modelcontextprotocol.io/)
 [![pnpm](https://img.shields.io/badge/pnpm-10.x-F69220.svg)](https://pnpm.io/)
 
-### A search-first, profile-aware reverse-engineering workspace for AI agents.
+**A search-first, profile-aware reverse-engineering workspace for AI agents.**
 
 **Hook the page, capture the network, deobfuscate the bundle, disassemble the WASM, instrument the process — and let one MCP server keep the whole attack surface in reach without drowning the model in schemas.**
 
@@ -23,7 +23,7 @@ English · [中文](./README.zh.md)
   <a href="https://github.com/vmoranv/jshookmcp/network/members">
     <img src="https://img.shields.io/github/forks/vmoranv/jshookmcp?style=for-the-badge" alt="Forks" />
   </a>
-  <a href="https://github.com/vmoranv/jshookmcp/releases/tag/v0.3.5">
+  <a href="https://github.com/vmoranv/jshookmcp/releases">
     <img src="https://img.shields.io/github/v/tag/vmoranv/jshookmcp?style=for-the-badge&sort=semver" alt="Latest Release" />
   </a>
   <a href="LICENSE">
@@ -32,11 +32,9 @@ English · [中文](./README.zh.md)
 </p>
 
 <p align="center">
-  <a href="https://www.npmjs.com/package/@jshookmcp/jshook">
-    <img src="https://img.shields.io/npm/v/@jshookmcp/jshook?style=for-the-badge&logo=npm" alt="npm version" />
-  </a>
+  <!-- npm badge: re-add once @jshookmcp/jshook is published -->
   <a href="https://nodejs.org/">
-    <img src="https://img.shields.io/badge/node-22.12%2B-brightgreen?style=for-the-badge&logo=node.js" alt="Node.js 22.12+" />
+    <img src="https://img.shields.io/badge/node-22.22.2%2B-brightgreen?style=for-the-badge&logo=node.js" alt="Node.js 22.22.2+" />
   </a>
   <a href="https://www.typescriptlang.org/">
     <img src="https://img.shields.io/badge/TypeScript-strict-3178C6?style=for-the-badge&logo=typescript&logoColor=white" alt="TypeScript strict" />
@@ -94,7 +92,7 @@ Most MCP servers for JS analysis expose a handful of hand-rolled tools or wrap a
 
 ## Capability overview
 
-A scan of what's in the box. Each row links to the detailed [Feature map](#full-feature-map) below.
+A scan of what's in the box. Each row links to the detailed [Capability overview](#capability-overview) below.
 
 | Area | Highlights |
 | --- | --- |

--- a/README.zh.md
+++ b/README.zh.md
@@ -10,7 +10,7 @@
 [![MCP](https://img.shields.io/badge/MCP-current-8A2BE2.svg)](https://modelcontextprotocol.io/)
 [![pnpm](https://img.shields.io/badge/pnpm-10.x-F69220.svg)](https://pnpm.io/)
 
-### 一个为 AI 智能体打造的搜索优先、档位可调的前端逆向工程工作台。
+**一个为 AI 智能体打造的搜索优先、档位可调的前端逆向工程工作台。**
 
 [English](./README.md) · 中文
 
@@ -21,7 +21,7 @@
   <a href="https://github.com/vmoranv/jshookmcp/network/members">
     <img src="https://img.shields.io/github/forks/vmoranv/jshookmcp?style=for-the-badge" alt="Forks" />
   </a>
-  <a href="https://github.com/vmoranv/jshookmcp/releases/tag/v0.3.5">
+  <a href="https://github.com/vmoranv/jshookmcp/releases">
     <img src="https://img.shields.io/github/v/tag/vmoranv/jshookmcp?style=for-the-badge&sort=semver" alt="最新版本" />
   </a>
   <a href="LICENSE">
@@ -30,11 +30,9 @@
 </p>
 
 <p align="center">
-  <a href="https://www.npmjs.com/package/@jshookmcp/jshook">
-    <img src="https://img.shields.io/npm/v/@jshookmcp/jshook?style=for-the-badge&logo=npm" alt="npm version" />
-  </a>
+  <!-- npm badge: re-add once @jshookmcp/jshook is published -->
   <a href="https://nodejs.org/">
-    <img src="https://img.shields.io/badge/node-22.12%2B-brightgreen?style=for-the-badge&logo=node.js" alt="Node.js 22.12+" />
+    <img src="https://img.shields.io/badge/node-22.22.2%2B-brightgreen?style=for-the-badge&logo=node.js" alt="Node.js 22.22.2+" />
   </a>
   <a href="https://www.typescriptlang.org/">
     <img src="https://img.shields.io/badge/TypeScript-strict-3178C6?style=for-the-badge&logo=typescript&logoColor=white" alt="TypeScript strict" />
@@ -92,7 +90,7 @@
 
 ## 能力概览
 
-下面是开箱即用能力的快速扫描。每一行都链向下方的 [完整功能图](#完整功能图)。
+下面是开箱即用能力的快速扫描。每一行都链向下方的 [能力概览](#能力概览)。
 
 | 能力域 | 亮点 |
 | --- | --- |

--- a/src/modules/binary-instrument/FridaSession.ts
+++ b/src/modules/binary-instrument/FridaSession.ts
@@ -732,8 +732,9 @@ export class FridaSession {
           encoding: 'utf8',
           // POSIX: lead a new process group so cancellation can signal the
           // whole tree — in spawn mode the instrumented target is a
-          // grandchild of the frida CLI.
-          detached: process.platform !== 'win32',
+          // grandchild of the frida CLI. ExecFileOptions omits `detached`;
+          // execFile forwards spawn options at runtime, hence the spread.
+          ...(process.platform !== 'win32' ? { detached: true as const } : {}),
         },
         (error, stdout, stderr) => {
           signal?.removeEventListener('abort', onAbort);
@@ -772,14 +773,15 @@ export class FridaSession {
           );
           return;
         }
+        const pid = child.pid;
         try {
-          process.kill(-child.pid, 'SIGTERM');
+          process.kill(-pid, 'SIGTERM');
         } catch {
           child.kill('SIGTERM');
         }
         escalationTimer = setTimeout(() => {
           try {
-            process.kill(-child.pid, 'SIGKILL');
+            process.kill(-pid, 'SIGKILL');
           } catch {
             child.kill('SIGKILL');
           }


### PR DESCRIPTION
Fixes the four red checks on the #154 merge commit:

- **markdownlint**: tagline demoted from h3 to bold paragraph (MD001 increment + MD026 punctuation); `Feature map / 完整功能图` fragment links now target the real `Capability overview / 能力概览` anchors (MD051)
- **lychee**: release badge now links to `/releases` (the v0.3.5 tag page 404s until a release is cut); npm badge removed until `@jshookmcp/jshook` is published (npm page 404s) — re-add noted in a comment; the second Node badge synced to 22.22.2+ (missed by #153)
- **linux-full typecheck**: my #151 frida tree-kill used `detached` inside execFile options — the `ExecFileOptions` type omits it (TS2769 + implicit-any callback params). Now passed via conditional spread (execFile forwards spawn options at runtime); escalation timer captures `child.pid` first so the closure keeps a narrowed number (TS18048). `tsc --noEmit` clean; FridaSession tests 24/24

The remaining lychee `[403]`s on api.star-history.com / stargazers are rate-limit flakiness on pre-existing embeds.

## Summary by Sourcery

Restore post-merge documentation link health and TypeScript validation across the project.

Bug Fixes:
- Resolve Frida process-tree termination type-check errors so the Linux full typecheck passes.

Enhancements:
- Align English and Chinese README formatting and internal links with their actual headings.
- Update release and Node.js badges while removing the unpublished npm badge to prevent broken links.

Documentation:
- Fix README markdownlint issues and broken badge and anchor links in both language versions.