### PR TITLE
fix(ci): document the registration lock timeout + align its runtime default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,10 @@
 # Copy to `.env` only when you need to override built-in defaults.
 # If a key is omitted, runtime falls back to the defaults in the config/constants layer.
 
+# ── Instances (src/utils/InstanceRegistry.ts) ──────────────────────────
+# Acquire-wait ceiling for the instance registration lock, in ms.
+# JSHOOK_REGISTRATION_LOCK_TIMEOUT_MS=5000
+
 # ── Browser / Puppeteer ────────────────────────────────────────────────
 PUPPETEER_EXECUTABLE_PATH=
 CHROME_PATH=

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -7,7 +7,10 @@ exclude = [
   "^ws://localhost",
   # star-history.com image API intermittently returns 503 (external service
   # flakiness, not a real broken link) — exclude to keep Repo Hygiene stable.
-  "^https://api\\.star-history\\.com"
+  "^https://api\\.star-history\\.com",
+  # github.com/stargazers intermittently 404s for token-less scans (GitHub
+  # anonymous rate limiting) — the page itself is fine.
+  "^https://github\\.com/vmoranv/jshookmcp/stargazers"
 ]
 exclude_path = [
   "docs/.vitepress/dist/assets/**",

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![MCP](https://img.shields.io/badge/MCP-current-8A2BE2.svg)](https://modelcontextprotocol.io/)
 [![pnpm](https://img.shields.io/badge/pnpm-10.x-F69220.svg)](https://pnpm.io/)
 
-### A search-first, profile-aware reverse-engineering workspace for AI agents.
+**A search-first, profile-aware reverse-engineering workspace for AI agents.**
 
 **Hook the page, capture the network, deobfuscate the bundle, disassemble the WASM, instrument the process — and let one MCP server keep the whole attack surface in reach without drowning the model in schemas.**
 
@@ -23,7 +23,7 @@ English · [中文](./README.zh.md)
   <a href="https://github.com/vmoranv/jshookmcp/network/members">
     <img src="https://img.shields.io/github/forks/vmoranv/jshookmcp?style=for-the-badge" alt="Forks" />
   </a>
-  <a href="https://github.com/vmoranv/jshookmcp/releases/tag/v0.3.5">
+  <a href="https://github.com/vmoranv/jshookmcp/releases">
     <img src="https://img.shields.io/github/v/tag/vmoranv/jshookmcp?style=for-the-badge&sort=semver" alt="Latest Release" />
   </a>
   <a href="LICENSE">
@@ -32,11 +32,9 @@ English · [中文](./README.zh.md)
 </p>
 
 <p align="center">
-  <a href="https://www.npmjs.com/package/@jshookmcp/jshook">
-    <img src="https://img.shields.io/npm/v/@jshookmcp/jshook?style=for-the-badge&logo=npm" alt="npm version" />
-  </a>
+  <!-- npm badge: re-add once @jshookmcp/jshook is published -->
   <a href="https://nodejs.org/">
-    <img src="https://img.shields.io/badge/node-22.12%2B-brightgreen?style=for-the-badge&logo=node.js" alt="Node.js 22.12+" />
+    <img src="https://img.shields.io/badge/node-22.22.2%2B-brightgreen?style=for-the-badge&logo=node.js" alt="Node.js 22.22.2+" />
   </a>
   <a href="https://www.typescriptlang.org/">
     <img src="https://img.shields.io/badge/TypeScript-strict-3178C6?style=for-the-badge&logo=typescript&logoColor=white" alt="TypeScript strict" />
@@ -94,7 +92,7 @@ Most MCP servers for JS analysis expose a handful of hand-rolled tools or wrap a
 
 ## Capability overview
 
-A scan of what's in the box. Each row links to the detailed [Feature map](#full-feature-map) below.
+A scan of what's in the box. Each row links to the detailed [Capability overview](#capability-overview) below.
 
 | Area | Highlights |
 | --- | --- |

--- a/README.zh.md
+++ b/README.zh.md
@@ -10,7 +10,7 @@
 [![MCP](https://img.shields.io/badge/MCP-current-8A2BE2.svg)](https://modelcontextprotocol.io/)
 [![pnpm](https://img.shields.io/badge/pnpm-10.x-F69220.svg)](https://pnpm.io/)
 
-### 一个为 AI 智能体打造的搜索优先、档位可调的前端逆向工程工作台。
+**一个为 AI 智能体打造的搜索优先、档位可调的前端逆向工程工作台。**
 
 [English](./README.md) · 中文
 
@@ -21,7 +21,7 @@
   <a href="https://github.com/vmoranv/jshookmcp/network/members">
     <img src="https://img.shields.io/github/forks/vmoranv/jshookmcp?style=for-the-badge" alt="Forks" />
   </a>
-  <a href="https://github.com/vmoranv/jshookmcp/releases/tag/v0.3.5">
+  <a href="https://github.com/vmoranv/jshookmcp/releases">
     <img src="https://img.shields.io/github/v/tag/vmoranv/jshookmcp?style=for-the-badge&sort=semver" alt="最新版本" />
   </a>
   <a href="LICENSE">
@@ -30,11 +30,9 @@
 </p>
 
 <p align="center">
-  <a href="https://www.npmjs.com/package/@jshookmcp/jshook">
-    <img src="https://img.shields.io/npm/v/@jshookmcp/jshook?style=for-the-badge&logo=npm" alt="npm version" />
-  </a>
+  <!-- npm badge: re-add once @jshookmcp/jshook is published -->
   <a href="https://nodejs.org/">
-    <img src="https://img.shields.io/badge/node-22.12%2B-brightgreen?style=for-the-badge&logo=node.js" alt="Node.js 22.12+" />
+    <img src="https://img.shields.io/badge/node-22.22.2%2B-brightgreen?style=for-the-badge&logo=node.js" alt="Node.js 22.22.2+" />
   </a>
   <a href="https://www.typescriptlang.org/">
     <img src="https://img.shields.io/badge/TypeScript-strict-3178C6?style=for-the-badge&logo=typescript&logoColor=white" alt="TypeScript strict" />
@@ -92,7 +90,7 @@
 
 ## 能力概览
 
-下面是开箱即用能力的快速扫描。每一行都链向下方的 [完整功能图](#完整功能图)。
+下面是开箱即用能力的快速扫描。每一行都链向下方的 [能力概览](#能力概览)。
 
 | 能力域 | 亮点 |
 | --- | --- |

--- a/src/modules/binary-instrument/FridaSession.ts
+++ b/src/modules/binary-instrument/FridaSession.ts
@@ -732,8 +732,9 @@ export class FridaSession {
           encoding: 'utf8',
           // POSIX: lead a new process group so cancellation can signal the
           // whole tree — in spawn mode the instrumented target is a
-          // grandchild of the frida CLI.
-          detached: process.platform !== 'win32',
+          // grandchild of the frida CLI. ExecFileOptions omits `detached`;
+          // execFile forwards spawn options at runtime, hence the spread.
+          ...(process.platform !== 'win32' ? { detached: true as const } : {}),
         },
         (error, stdout, stderr) => {
           signal?.removeEventListener('abort', onAbort);
@@ -772,14 +773,15 @@ export class FridaSession {
           );
           return;
         }
+        const pid = child.pid;
         try {
-          process.kill(-child.pid, 'SIGTERM');
+          process.kill(-pid, 'SIGTERM');
         } catch {
           child.kill('SIGTERM');
         }
         escalationTimer = setTimeout(() => {
           try {
-            process.kill(-child.pid, 'SIGKILL');
+            process.kill(-pid, 'SIGKILL');
           } catch {
             child.kill('SIGKILL');
           }

--- a/src/utils/InstanceRegistry.ts
+++ b/src/utils/InstanceRegistry.ts
@@ -37,7 +37,7 @@ const registrationLockPath = () => resolve(instancesDir(), '.register-lock');
 
 /** Acquire-wait ceiling for the registration lock (ops-adjustable, tests shrink it). */
 function registrationLockTimeoutMs(): number {
-  const raw = Number(readEnvString('JSHOOK_REGISTRATION_LOCK_TIMEOUT_MS', ''));
+  const raw = Number(readEnvString('JSHOOK_REGISTRATION_LOCK_TIMEOUT_MS', '5000'));
   return Number.isFinite(raw) && raw > 0 ? raw : 5_000;
 }
 


### PR DESCRIPTION
Two follow-ups the #155 merge's CI surfaced:

1. **env-contract**: `JSHOOK_REGISTRATION_LOCK_TIMEOUT_MS` (introduced with #148's warn-only lock degradation) was read from env without a `.env.example` entry — documented under a new Instances section with its 5000ms default.
2. The contract compares the template value against the statically evaluated runtime default — `readEnvString`'s fallback is now `'5000'` so the two match.

Also excludes `github.com/vmoranv/jshookmcp/stargazers` from lychee: it intermittently 404s for token-less scans via anonymous GitHub rate limiting (same class as the existing star-history.com exclusion; the page itself is fine).

Verification: `pnpm vitest run env-example InstanceRegistry` -> 20/20.

## Summary by Sourcery

Align registration lock configuration, process cancellation, documentation, and link-check behavior with the current runtime and CI contracts.

Bug Fixes:
- Align the registration lock runtime fallback with the documented 5000 ms configuration contract.
- Improve Frida process cancellation reliability by preserving the child PID and correctly configuring process-group handling.
- Exclude the intermittently failing GitHub stargazers page from link checks.

CI:
- Update link-check exclusions to avoid transient failures from anonymous GitHub rate limiting.

Documentation:
- Document the registration lock timeout configuration and refresh README presentation, links, badges, and anchors in English and Chinese.